### PR TITLE
修改地图参数: ze_sandstorm_cs2

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_sandstorm_cs2.cfg
+++ b/2001/csgo/cfg/map-configs/ze_sandstorm_cs2.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "0.8"
 
 
 
@@ -151,13 +151,13 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "5"
+ze_weapons_round_hegrenade "4"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "5"
+ze_weapons_round_molotov "3"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
@@ -169,13 +169,13 @@ ze_weapons_round_decoy "3"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "-1"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_smoke "1"
+ze_weapons_round_smoke "-1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_sandstorm_cs2
## 为什么要增加/修改这个东西
该图守点较为简单，神器强力，在有人类道具黑洞和屏障雷的情况下甚至不需要神器,僵尸基本无法操作坐牢,故申请削弱击退已经参考cs1删除黑洞和屏障雷并且减少部分手雷火瓶购买数量
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
