### PR TITLE
补充地图翻译: ze_pokemon_kanto_v1

### DIFF
--- a/2001/sharp/data/translations/ze_pokemon_kanto_v1.jsonc
+++ b/2001/sharp/data/translations/ze_pokemon_kanto_v1.jsonc
@@ -8,7 +8,7 @@
   // clearText  (bool) -> 清除所有HUD文本
   // clearTimer (bool) -> 清除所有倒计时
   // countdown  (int)  -> 添加特殊的独立的倒计时
-
+  
   {
     "Map created by Bart": {
       "translation": "地图作者:bart地图翻译:余清茗染@Fys"

--- a/2001/sharp/data/translations/ze_pokemon_kanto_v1.jsonc
+++ b/2001/sharp/data/translations/ze_pokemon_kanto_v1.jsonc
@@ -8,328 +8,327 @@
   // clearText  (bool) -> 清除所有HUD文本
   // clearTimer (bool) -> 清除所有倒计时
   // countdown  (int)  -> 添加特殊的独立的倒计时
-  
-  {
-    "Map created by Bart": {
+
+{
+  "Map created by Bart": {
       "translation": "地图作者:bart地图翻译:余清茗染@Fys"
-    },
-    "Door will open in 15 seconds": {
-      "translation": "门将在15秒后开启"
-    },
-    "Spawn teleport will activate in 15 seconds": {
-      "translation": "未进入门的玩家将在15秒后进行传送"
-    },
-    "Hold for 30 seconds": {
-      "translation": "道路将在30秒后开启"
-    },
-    "Weedle is attacking us": {
-      "translation": "黄色毛虫正在攻击我们"
-    },
-    "Weedle is using poison sting": {
-      "translation": "黄色毛虫使用了毒刺"
-    },
-    "Weedle is dead": {
-      "translation": "黄色毛虫被我们收服了"
-    },
-    "Rattatas is attacking viridian city, kill them all": {
-      "translation": "拉达正潜伏在这座小镇,找到他们,干掉他们."
-    },
-    "Going into pokemon center will fully heal you": {
-      "translation": "口袋妖怪医院欢迎你"
-    },
-    "Second path have opened": {
-      "translation": "侧路已开"
-    },
-    "All Rattatas have been killed, guard door will open in 30 seconds": {
-      "translation": "看样子你们已经解决了所有拉达,道路将在30秒后开启"
-    },
-    "Zombies will TP in 15 seconds": {
-      "translation": "僵尸将在15秒后传送在圈内"
-    },
-    "Bulbasaur is attacking us": {
-      "translation": "是蒜头王八"
-    },
-    "Bulbasaur is using razor leaf": {
-      "translation": "蒜头王八使用了飞叶快刀"
-    },
-    "Bulbasaur is dead": {
-      "translation": "蒜头王八死了",
-    },
-    "A Magikarp is in the way": {
-      "translation": "是一只鲤鱼王挡住我们路了?,把他变成红烧鲤鱼王!",
-    },
-    "Magikarp is dead": {
-      "translation": "已经成功烹饪美食:红烧鲤鱼王"
-    },
-    "Pikachu is attacking us": {
-      "translation": "哦?是一只皮卡丘! 解决掉他."
-    },
-    "Pikachu is using spark attack": {
-      "translation": "哦?是一只皮卡丘! 解决掉他."
-    },
-    "Hold for 25 seconds": {
-      "translation": "道路将在25秒后开放"
-    },
-    "Zombies will TP in 20 seconds": {
-      "translation": "僵尸将在20秒后传送"
-    },
-    "Gym will open in 40 seconds": {
-      "translation": "道馆大门将在40秒后对你们开放" 
-    },
-    "Gym is open!": {
-      "translation": "开门喽" 
-    },
-    "Hold bridge for 30 seconds": {
-      "translation": "桥将在30秒后关闭" 
-    },
-    "Gym will open in 40 seconds": {
-      "translation": "道馆大门将在40秒后对你们开放" 
-    },
-    "Brock is challenging you": {
-      "translation": "是小刚" 
-    },
-    "Brock is picking Onix": {
-      "translation": "小刚召唤了大岩蛇" 
-    },
-    "Onix is using earthquake": {
-      "translation": "大岩蛇使用了地之元素" 
-    },
-    "Onix is using Rock Throw": {
-      "translation": "大岩蛇使用了岩之一击" 
-    },
-    "GOnix is defeated": {
-      "translation": "大岩蛇被击败了" 
-    },
-    "Stage 1 complete": {
-      "translation": "第一关结束了,GGWP" 
-    },
-    "Map created by Bart": {
-      "translation": "地图作者:bart地图翻译:余清茗染@Fys" 
-    },
-    "Door will open in 15 seconds": {
-      "translation": "门将在15秒后开启" 
-    },
-    "Spawn teleport will activate in 20 seconds": {
-      "translation": "未进入门的玩家将在20秒后进行传送" 
-    },
-    "Voltorb is blocking the way, kill him": {
-      "translation": "开枪把这个霹雳球打了,小心它会自爆" 
-    },
-    "Hold for 20 seconds": {
-      "translation": "道路将在20秒后开放" 
-    },
-    "Find and kill all digletts": {
-      "translation": "找到并击杀所有地鼠找到所有的地鼠,解决他们,道路才会开放" 
-    },
-    "All digletts have been killed, ladder will open in 30 seconds": {
-      "translation": "看样子你们解决了所有的地鼠,干得好,道路将在30秒后开放,注意摔伤" 
-    },
-    "Zombies will TP in 15 seconds": {
-      "translation": "15秒后僵尸传送" 
-    },
-    "Zubat is attacking us": {
-      "translation": "是超音蝠,他在对我们发起攻击" 
-    },
-    "Zubat is using Absorb": {
-      "translation": "超音蝠使用了超音波" 
-    },
-    "Zubat is dead": {
-      "translation": "干得好,超音蝠被你们解决了" 
-    },
-    "Golem is attacking us": {
-      "translation": "一只隆隆石挡住了去路" 
-    },
-    "Golem is using rock throw": {
-      "translation": "隆隆石发动了泥洪石流" 
-    },
-    "Golem is dead": {
-      "translation": "隆隆石被干掉了" 
-    },
-    "Hold for 40 seconds": {
-      "translation": "道路将在40秒后开放" 
-    },
-    "Zombies will TP in 20 seconds": {
-      "translation": "僵尸将在20秒后传送" 
-    },
-    "Gym will open in 40 seconds": {
-      "translation": "道馆将在40秒后对你们开放" 
-    },
-    "Gym is open": {
-      "translation": "道馆大门开启了" 
-    },
-    "Hold bridge for 30 seconds": {
-      "translation": "桥将在30秒后关闭" 
-    },
-    "Misty is challenging you": {
-      "translation": "是小霞" 
-    },
-    "Misty is picking Starmie": {
-      "translation": "小霞召唤了宝石海星" 
-    },
-    "Starmie is using Blizzard attack": {
-      "translation": "宝石海星吐了口口水对你" 
-    },
-    "Starmie is using Surf": {
-      "translation": "宝石海星使用了水之波动" 
-    },
-    "Starmie have been defeated!": {
-      "translation": "宝石海星被打败了" 
-    },
-    "Stage 2 complete": {
-      "translation": "第二关通关" 
-    },
-    "Map created by Bart": {
-      "translation": "地图作者:bart地图翻译:余清茗染@Fys" 
-    },
-    "Door will open in 15 seconds": {
-      "translation": "门将在15秒后开启" 
-    },
-    "Zombies will TP in 10 seconds": {
-      "translation": "僵尸将在10秒后传送在圈内" 
-    },
-    "Nidorino is attacking us": {
-      "translation": "一只尼多兰挡住了去路" 
-    },
-    "Nidorino is using horn attack": {
-      "translation": "尼多兰正在使用穿刺攻击" 
-    },
-    "Nidorino is dead": {
-      "translation": "尼多兰被打败了" 
-    },
-    "Hold for 30 seconds": {
-      "translation": "道路将在30秒后开启" 
-    },
-    "Zombies will TP in 30 seconds": {
-      "translation": "僵尸将在30秒后传送" 
-    },
-    "Hold for 25 seconds": {
-      "translation": "25秒后门开" 
-    },
-    "Door is open!": {
-      "translation": "撤退" 
-    },
-    "Golem is back for revenge": {
-      "translation": "隆隆石回来复仇了,他好像变得更厉害了" 
-    },
-    "Golem is using rock throw": {
-      "translation": "隆隆石正在使用岩石投掷" 
-    },
-    "Golem is dead": {
-      "translation": "隆隆石彻底没了" 
-    },
-    "Hold for 45 seconds": {
-      "translation": "45秒后道路开放" 
-    },
-    "Zombies will TP in 15 seconds": {
-      "translation": "僵尸将在15秒后传送" 
-    },
-    "Gym will open in 60 seconds": {
-      "translation": "道馆大门将在60秒后开启" 
-    },
-    "Gym is open": {
-      "translation": "道馆大门已开启" 
-    },
-    "Hold bridge for 30 seconds": {
-      "translation": "桥将在30秒后关闭" 
-    },
-    "Lt Surge is challenging you": {
-      "translation": "浪永中尉接受了你的挑战" 
-    },
-    "Lt Surge is picking Raichu": {
-      "translation": "浪永召唤了雷丘" 
-    },
-    "Raichu is using electro ball": {
-      "translation": "雷丘使用了雷电球" 
-    },
-    "Raichu is using Spark attack on RIGHT side": {
-      "translation": "雷丘在右半场使用了十万伏特" 
-    },
-    "Raichu is using Spark attack on LEFT side": {
-      "translation": "雷丘在左半场使用了十万伏特" 
-    },
-    "Raichu have been defeated": {
-      "translation": "雷丘被击败了" 
-    },
-    "Stage 3 complete": {
-      "translation": "第三关完成" 
-    },
-    "Map created by Bart": {
-      "translation": "地图作者:bart地图翻译:余清茗染@Fys" 
-    },
-    "Door will open in 15 seconds": {
-      "translation": "门将在15秒后开启" 
-    },
-    "Spawn teleport will activate in 20 seconds": {
-      "translation": "未进入门的玩家将在20秒后进行传送" 
-    },
-    "Hold for 45 seconds": {
-      "translation": "道路将在45秒后开启" 
-    },
-    "Guard door is open, fall back": {
-      "translation": "道路已开通,撤退" 
-    },
-    "Squirtle is attacking us": {
-      "translation": "是一只杰尼龟" 
-    },
-    "Squirtle is using surf": {
-      "translation": "杰尼龟正在攻击我们" 
-    },
-    "Zombies teleport in 25 seconds": {
-      "translation": "僵尸将在25秒后传送" 
-    },
-    "Hold for 50 seconds": {
-      "translation": "守住50秒" 
-    },
-    "Guard door is open, fall back": {
-      "translation": "道路已开通,撤退" 
-    },
-    "耿鬼隐藏在薰衣草镇,找到并杀死它,解除诅咒": {
-      "translation": "道路已开通,撤退" 
-    },
-    "Gengar used Curse": {
-      "translation": "耿鬼在背后使用诅咒" 
-    },
-    "Gengar have been defeated, hold for 20 seconds": {
-      "translation": "耿鬼已被击败,道路将在20秒后开通" 
-    },
-    "Zombies teleport in 20 seconds": {
-      "translation": "僵尸15秒后传送" 
-    },
-    "Hold for 40 seconds": {
-      "translation": "道路将在40秒后开放" 
-    },
-    "Gym opens in 20 seconds": {
-      "translation": "道馆将在20秒后开放" 
-    },
-    "Gym is open!": {
-      "translation": "道路已开通,撤退" 
-    },
-    "Hold for 30 seconds": {
-      "translation": "桥将在30秒后关闭" 
-    },
-    "Sabrina is challenging you": {
-      "translation": "萨布丽娜在挑战你" 
-    },
-    "Sabrina is picking Alakazam": {
-      "translation": "萨布丽娜召唤了胡地" 
-    },
-    "Alakazam is using psychic on LEFT side": {
-      "translation": "胡地在左半场使用了迷雾幻象" 
-    },
-    "Alakazam is using Shadowball, GET OUT OF THE MIDDLE": {
-      "translation": "胡地使用了暗影球" 
-    },
-    "Alakazam is using psychic on RIGHT side": {
-      "translation": "胡地在右半场使用了迷雾幻象" 
-    },
-    "Stage 4 completed": {
-      "translation": "最终关已通关" 
-    },
-    "More stages will be added in the future": {
-      "translation": "未来,我们会有更精彩的舞台" 
-    },
-    "Map is over, RTV!": {
-      "translation": "地图已全图通关,RTV RTV" 
-    }  
+  },
+  "Door will open in 15 seconds": {
+    "translation": "门将在15秒后开启"
+  },
+  "Spawn teleport will activate in 15 seconds": {
+    "translation": "未进入门的玩家将在15秒后进行传送"
+  },
+  "Hold for 30 seconds": {
+    "translation": "道路将在30秒后开启"
+  },
+  "Weedle is attacking us": {
+    "translation": "黄色毛虫正在攻击我们"
+  },
+  "Weedle is using poison sting": {
+    "translation": "黄色毛虫使用了毒刺"
+  },
+  "Weedle is dead": {
+    "translation": "黄色毛虫被我们收服了"
+  },
+  "Rattatas is attacking viridian city, kill them all": {
+    "translation": "拉达正潜伏在这座小镇,找到他们,干掉他们."
+  },
+  "Going into pokemon center will fully heal you": {
+    "translation": "口袋妖怪医院欢迎你"
+  },
+  "Second path have opened": {
+    "translation": "侧路已开"
+  },
+  "All Rattatas have been killed, guard door will open in 30 seconds": {
+    "translation": "看样子你们已经解决了所有拉达,道路将在30秒后开启"
+  },
+  "Zombies will TP in 15 seconds": {
+    "translation": "僵尸将在15秒后传送在圈内"
+  },
+  "Bulbasaur is attacking us": {
+    "translation": "是蒜头王八"
+  },
+  "Bulbasaur is using razor leaf": {
+    "translation": "蒜头王八使用了飞叶快刀"
+  },
+  "Bulbasaur is dead": {
+    "translation": "蒜头王八死了",
+  },
+  "A Magikarp is in the way": {
+    "translation": "是一只鲤鱼王挡住我们路了?,把他变成红烧鲤鱼王!",
+  },
+  "Magikarp is dead": {
+    "translation": "已经成功烹饪美食:红烧鲤鱼王"
+  },
+  "Pikachu is attacking us": {
+    "translation": "哦?是一只皮卡丘! 解决掉他."
+  },
+  "Pikachu is using spark attack": {
+    "translation": "哦?是一只皮卡丘! 解决掉他."
+  },
+  "Hold for 25 seconds": {
+    "translation": "道路将在25秒后开放"
+  },
+  "Zombies will TP in 20 seconds": {
+    "translation": "僵尸将在20秒后传送"
+  },
+  "Gym will open in 40 seconds": {
+    "translation": "道馆大门将在40秒后对你们开放" 
+  },
+  "Gym is open!": {
+    "translation": "开门喽" 
+  },
+  "Hold bridge for 30 seconds": {
+    "translation": "桥将在30秒后关闭" 
+  },
+  "Gym will open in 40 seconds": {
+    "translation": "道馆大门将在40秒后对你们开放" 
+  },
+  "Brock is challenging you": {
+    "translation": "是小刚" 
+  },
+  "Brock is picking Onix": {
+    "translation": "小刚召唤了大岩蛇" 
+  },
+  "Onix is using earthquake": {
+    "translation": "大岩蛇使用了地之元素" 
+  },
+  "Onix is using Rock Throw": {
+    "translation": "大岩蛇使用了岩之一击" 
+  },
+  "GOnix is defeated": {
+    "translation": "大岩蛇被击败了" 
+  },
+  "Stage 1 complete": {
+    "translation": "第一关结束了,GGWP" 
+  },
+  "Map created by Bart": {
+    "translation": "地图作者:bart地图翻译:余清茗染@Fys" 
+  },
+  "Door will open in 15 seconds": {
+    "translation": "门将在15秒后开启" 
+  },
+  "Spawn teleport will activate in 20 seconds": {
+    "translation": "未进入门的玩家将在20秒后进行传送" 
+  },
+  "Voltorb is blocking the way, kill him": {
+    "translation": "开枪把这个霹雳球打了,小心它会自爆" 
+  },
+  "Hold for 20 seconds": {
+    "translation": "道路将在20秒后开放" 
+  },
+  "Find and kill all digletts": {
+    "translation": "找到并击杀所有地鼠找到所有的地鼠,解决他们,道路才会开放" 
+  },
+  "All digletts have been killed, ladder will open in 30 seconds": {
+    "translation": "看样子你们解决了所有的地鼠,干得好,道路将在30秒后开放,注意摔伤" 
+  },
+  "Zombies will TP in 15 seconds": {
+    "translation": "15秒后僵尸传送" 
+  },
+  "Zubat is attacking us": {
+    "translation": "是超音蝠,他在对我们发起攻击" 
+  },
+  "Zubat is using Absorb": {
+    "translation": "超音蝠使用了超音波" 
+  },
+  "Zubat is dead": {
+    "translation": "干得好,超音蝠被你们解决了" 
+  },
+  "Golem is attacking us": {
+    "translation": "一只隆隆石挡住了去路" 
+  },
+  "Golem is using rock throw": {
+    "translation": "隆隆石发动了泥洪石流" 
+  },
+  "Golem is dead": {
+    "translation": "隆隆石被干掉了" 
+  },
+  "Hold for 40 seconds": {
+    "translation": "道路将在40秒后开放" 
+  },
+  "Zombies will TP in 20 seconds": {
+    "translation": "僵尸将在20秒后传送" 
+  },
+  "Gym will open in 40 seconds": {
+    "translation": "道馆将在40秒后对你们开放" 
+  },
+  "Gym is open": {
+    "translation": "道馆大门开启了" 
+  },
+  "Hold bridge for 30 seconds": {
+    "translation": "桥将在30秒后关闭" 
+  },
+  "Misty is challenging you": {
+    "translation": "是小霞" 
+  },
+  "Misty is picking Starmie": {
+    "translation": "小霞召唤了宝石海星" 
+  },
+  "Starmie is using Blizzard attack": {
+    "translation": "宝石海星吐了口口水对你" 
+  },
+  "Starmie is using Surf": {
+    "translation": "宝石海星使用了水之波动" 
+  },
+  "Starmie have been defeated!": {
+    "translation": "宝石海星被打败了" 
+  },
+  "Stage 2 complete": {
+    "translation": "第二关通关" 
+  },
+  "Map created by Bart": {
+    "translation": "地图作者:bart地图翻译:余清茗染@Fys" 
+  },
+  "Door will open in 15 seconds": {
+    "translation": "门将在15秒后开启" 
+  },
+  "Zombies will TP in 10 seconds": {
+    "translation": "僵尸将在10秒后传送在圈内" 
+  },
+  "Nidorino is attacking us": {
+    "translation": "一只尼多兰挡住了去路" 
+  },
+  "Nidorino is using horn attack": {
+    "translation": "尼多兰正在使用穿刺攻击" 
+  },
+  "Nidorino is dead": {
+    "translation": "尼多兰被打败了" 
+  },
+  "Hold for 30 seconds": {
+    "translation": "道路将在30秒后开启" 
+  },
+  "Zombies will TP in 30 seconds": {
+    "translation": "僵尸将在30秒后传送" 
+  },
+  "Hold for 25 seconds": {
+    "translation": "25秒后门开" 
+  },
+  "Door is open!": {
+    "translation": "撤退" 
+  },
+  "Golem is back for revenge": {
+    "translation": "隆隆石回来复仇了,他好像变得更厉害了" 
+  },
+  "Golem is using rock throw": {
+    "translation": "隆隆石正在使用岩石投掷" 
+  },
+  "Golem is dead": {
+    "translation": "隆隆石彻底没了" 
+  },
+  "Hold for 45 seconds": {
+    "translation": "45秒后道路开放" 
+  },
+  "Zombies will TP in 15 seconds": {
+    "translation": "僵尸将在15秒后传送" 
+  },
+   "Gym will open in 60 seconds": {
+    "translation": "道馆大门将在60秒后开启" 
+  },
+  "Gym is open": {
+    "translation": "道馆大门已开启" 
+  },
+  "Hold bridge for 30 seconds": {
+    "translation": "桥将在30秒后关闭" 
+  },
+  "Lt Surge is challenging you": {
+    "translation": "浪永中尉接受了你的挑战" 
+  },
+  "Lt Surge is picking Raichu": {
+    "translation": "浪永召唤了雷丘" 
+  },
+  "Raichu is using electro ball": {
+    "translation": "雷丘使用了雷电球" 
+  },
+  "Raichu is using Spark attack on RIGHT side": {
+    "translation": "雷丘在右半场使用了十万伏特" 
+  },
+  "Raichu is using Spark attack on LEFT side": {
+    "translation": "雷丘在左半场使用了十万伏特" 
+  },
+  "Raichu have been defeated": {
+    "translation": "雷丘被击败了" 
+  },
+  "Stage 3 complete": {
+    "translation": "第三关完成" 
+  },
+  "Map created by Bart": {
+    "translation": "地图作者:bart地图翻译:余清茗染@Fys" 
+  },
+  "Door will open in 15 seconds": {
+    "translation": "门将在15秒后开启" 
+  },
+  "Spawn teleport will activate in 20 seconds": {
+    "translation": "未进入门的玩家将在20秒后进行传送" 
+  },
+  "Hold for 45 seconds": {
+    "translation": "道路将在45秒后开启" 
+  },
+  "Guard door is open, fall back": {
+    "translation": "道路已开通,撤退" 
+  },
+  "Squirtle is attacking us": {
+    "translation": "是一只杰尼龟" 
+  },
+  "Squirtle is using surf": {
+    "translation": "杰尼龟正在攻击我们" 
+  },
+  "Zombies teleport in 25 seconds": {
+    "translation": "僵尸将在25秒后传送" 
+  },
+  "Hold for 50 seconds": {
+    "translation": "守住50秒" 
+  },
+  "Guard door is open, fall back": {
+    "translation": "道路已开通,撤退" 
+  },
+  "耿鬼隐藏在薰衣草镇,找到并杀死它,解除诅咒": {
+    "translation": "道路已开通,撤退" 
+  },
+  "Gengar used Curse": {
+    "translation": "耿鬼在背后使用诅咒" 
+  },
+  "Gengar have been defeated, hold for 20 seconds": {
+    "translation": "耿鬼已被击败,道路将在20秒后开通" 
+  },
+  "Zombies teleport in 20 seconds": {
+    "translation": "僵尸15秒后传送" 
+  },
+  "Hold for 40 seconds": {
+    "translation": "道路将在40秒后开放" 
+  },
+  "Gym opens in 20 seconds": {
+    "translation": "道馆将在20秒后开放" 
+  },
+  "Gym is open!": {
+    "translation": "道路已开通,撤退" 
+  },
+  "Hold for 30 seconds": {
+    "translation": "桥将在30秒后关闭" 
+  },
+  "Sabrina is challenging you": {
+    "translation": "萨布丽娜在挑战你" 
+  },
+  "Sabrina is picking Alakazam": {
+    "translation": "萨布丽娜召唤了胡地" 
+  },
+  "Alakazam is using psychic on LEFT side": {
+    "translation": "胡地在左半场使用了迷雾幻象" 
+  },
+  "Alakazam is using Shadowball, GET OUT OF THE MIDDLE": {
+    "translation": "胡地使用了暗影球" 
+  },
+  "Alakazam is using psychic on RIGHT side": {
+    "translation": "胡地在右半场使用了迷雾幻象" 
+  },
+  "Stage 4 completed": {
+    "translation": "最终关已通关" 
+  },
+  "More stages will be added in the future": {
+    "translation": "未来,我们会有更精彩的舞台" 
+  },
+  "Map is over, RTV!": {
+    "translation": "地图已全图通关,RTV RTV" 
   }
-  
+}

--- a/2001/sharp/data/translations/ze_pokemon_kanto_v1.jsonc
+++ b/2001/sharp/data/translations/ze_pokemon_kanto_v1.jsonc
@@ -11,7 +11,7 @@
 
 {
   "Map created by Bart": {
-      "translation": "地图作者:bart地图翻译:余清茗染@Fys"
+    "translation": "地图作者:bart地图翻译:余清茗染@Fys"
   },
   "Door will open in 15 seconds": {
     "translation": "门将在15秒后开启"
@@ -223,7 +223,7 @@
   "Zombies will TP in 15 seconds": {
     "translation": "僵尸将在15秒后传送" 
   },
-   "Gym will open in 60 seconds": {
+  "Gym will open in 60 seconds": {
     "translation": "道馆大门将在60秒后开启" 
   },
   "Gym is open": {

--- a/2001/sharp/data/translations/ze_pokemon_kanto_v1.jsonc
+++ b/2001/sharp/data/translations/ze_pokemon_kanto_v1.jsonc
@@ -1,0 +1,335 @@
+// Console SayText i18n file generator.
+// i18n Version v21
+// Copyright 2024 Kyle 'Kxnrl' Frankiss.
+// https://github.com/Kxnrl
+
+  // 可用字段:
+  // blocked    (bool) -> 屏蔽本句输出
+  // clearText  (bool) -> 清除所有HUD文本
+  // clearTimer (bool) -> 清除所有倒计时
+  // countdown  (int)  -> 添加特殊的独立的倒计时
+
+  {
+    "Map created by Bart": {
+      "translation": "地图作者:bart地图翻译:余清茗染@Fys"
+    },
+    "Door will open in 15 seconds": {
+      "translation": "门将在15秒后开启"
+    },
+    "Spawn teleport will activate in 15 seconds": {
+      "translation": "未进入门的玩家将在15秒后进行传送"
+    },
+    "Hold for 30 seconds": {
+      "translation": "道路将在30秒后开启"
+    },
+    "Weedle is attacking us": {
+      "translation": "黄色毛虫正在攻击我们"
+    },
+    "Weedle is using poison sting": {
+      "translation": "黄色毛虫使用了毒刺"
+    },
+    "Weedle is dead": {
+      "translation": "黄色毛虫被我们收服了"
+    },
+    "Rattatas is attacking viridian city, kill them all": {
+      "translation": "拉达正潜伏在这座小镇,找到他们,干掉他们."
+    },
+    "Going into pokemon center will fully heal you": {
+      "translation": "口袋妖怪医院欢迎你"
+    },
+    "Second path have opened": {
+      "translation": "侧路已开"
+    },
+    "All Rattatas have been killed, guard door will open in 30 seconds": {
+      "translation": "看样子你们已经解决了所有拉达,道路将在30秒后开启"
+    },
+    "Zombies will TP in 15 seconds": {
+      "translation": "僵尸将在15秒后传送在圈内"
+    },
+    "Bulbasaur is attacking us": {
+      "translation": "是蒜头王八"
+    },
+    "Bulbasaur is using razor leaf": {
+      "translation": "蒜头王八使用了飞叶快刀"
+    },
+    "Bulbasaur is dead": {
+      "translation": "蒜头王八死了",
+    },
+    "A Magikarp is in the way": {
+      "translation": "是一只鲤鱼王挡住我们路了?,把他变成红烧鲤鱼王!",
+    },
+    "Magikarp is dead": {
+      "translation": "已经成功烹饪美食:红烧鲤鱼王"
+    },
+    "Pikachu is attacking us": {
+      "translation": "哦?是一只皮卡丘! 解决掉他."
+    },
+    "Pikachu is using spark attack": {
+      "translation": "哦?是一只皮卡丘! 解决掉他."
+    },
+    "Hold for 25 seconds": {
+      "translation": "道路将在25秒后开放"
+    },
+    "Zombies will TP in 20 seconds": {
+      "translation": "僵尸将在20秒后传送"
+    },
+    "Gym will open in 40 seconds": {
+      "translation": "道馆大门将在40秒后对你们开放" 
+    },
+    "Gym is open!": {
+      "translation": "开门喽" 
+    },
+    "Hold bridge for 30 seconds": {
+      "translation": "桥将在30秒后关闭" 
+    },
+    "Gym will open in 40 seconds": {
+      "translation": "道馆大门将在40秒后对你们开放" 
+    },
+    "Brock is challenging you": {
+      "translation": "是小刚" 
+    },
+    "Brock is picking Onix": {
+      "translation": "小刚召唤了大岩蛇" 
+    },
+    "Onix is using earthquake": {
+      "translation": "大岩蛇使用了地之元素" 
+    },
+    "Onix is using Rock Throw": {
+      "translation": "大岩蛇使用了岩之一击" 
+    },
+    "GOnix is defeated": {
+      "translation": "大岩蛇被击败了" 
+    },
+    "Stage 1 complete": {
+      "translation": "第一关结束了,GGWP" 
+    },
+    "Map created by Bart": {
+      "translation": "地图作者:bart地图翻译:余清茗染@Fys" 
+    },
+    "Door will open in 15 seconds": {
+      "translation": "门将在15秒后开启" 
+    },
+    "Spawn teleport will activate in 20 seconds": {
+      "translation": "未进入门的玩家将在20秒后进行传送" 
+    },
+    "Voltorb is blocking the way, kill him": {
+      "translation": "开枪把这个霹雳球打了,小心它会自爆" 
+    },
+    "Hold for 20 seconds": {
+      "translation": "道路将在20秒后开放" 
+    },
+    "Find and kill all digletts": {
+      "translation": "找到并击杀所有地鼠找到所有的地鼠,解决他们,道路才会开放" 
+    },
+    "All digletts have been killed, ladder will open in 30 seconds": {
+      "translation": "看样子你们解决了所有的地鼠,干得好,道路将在30秒后开放,注意摔伤" 
+    },
+    "Zombies will TP in 15 seconds": {
+      "translation": "15秒后僵尸传送" 
+    },
+    "Zubat is attacking us": {
+      "translation": "是超音蝠,他在对我们发起攻击" 
+    },
+    "Zubat is using Absorb": {
+      "translation": "超音蝠使用了超音波" 
+    },
+    "Zubat is dead": {
+      "translation": "干得好,超音蝠被你们解决了" 
+    },
+    "Golem is attacking us": {
+      "translation": "一只隆隆石挡住了去路" 
+    },
+    "Golem is using rock throw": {
+      "translation": "隆隆石发动了泥洪石流" 
+    },
+    "Golem is dead": {
+      "translation": "隆隆石被干掉了" 
+    },
+    "Hold for 40 seconds": {
+      "translation": "道路将在40秒后开放" 
+    },
+    "Zombies will TP in 20 seconds": {
+      "translation": "僵尸将在20秒后传送" 
+    },
+    "Gym will open in 40 seconds": {
+      "translation": "道馆将在40秒后对你们开放" 
+    },
+    "Gym is open": {
+      "translation": "道馆大门开启了" 
+    },
+    "Hold bridge for 30 seconds": {
+      "translation": "桥将在30秒后关闭" 
+    },
+    "Misty is challenging you": {
+      "translation": "是小霞" 
+    },
+    "Misty is picking Starmie": {
+      "translation": "小霞召唤了宝石海星" 
+    },
+    "Starmie is using Blizzard attack": {
+      "translation": "宝石海星吐了口口水对你" 
+    },
+    "Starmie is using Surf": {
+      "translation": "宝石海星使用了水之波动" 
+    },
+    "Starmie have been defeated!": {
+      "translation": "宝石海星被打败了" 
+    },
+    "Stage 2 complete": {
+      "translation": "第二关通关" 
+    },
+    "Map created by Bart": {
+      "translation": "地图作者:bart地图翻译:余清茗染@Fys" 
+    },
+    "Door will open in 15 seconds": {
+      "translation": "门将在15秒后开启" 
+    },
+    "Zombies will TP in 10 seconds": {
+      "translation": "僵尸将在10秒后传送在圈内" 
+    },
+    "Nidorino is attacking us": {
+      "translation": "一只尼多兰挡住了去路" 
+    },
+    "Nidorino is using horn attack": {
+      "translation": "尼多兰正在使用穿刺攻击" 
+    },
+    "Nidorino is dead": {
+      "translation": "尼多兰被打败了" 
+    },
+    "Hold for 30 seconds": {
+      "translation": "道路将在30秒后开启" 
+    },
+    "Zombies will TP in 30 seconds": {
+      "translation": "僵尸将在30秒后传送" 
+    },
+    "Hold for 25 seconds": {
+      "translation": "25秒后门开" 
+    },
+    "Door is open!": {
+      "translation": "撤退" 
+    },
+    "Golem is back for revenge": {
+      "translation": "隆隆石回来复仇了,他好像变得更厉害了" 
+    },
+    "Golem is using rock throw": {
+      "translation": "隆隆石正在使用岩石投掷" 
+    },
+    "Golem is dead": {
+      "translation": "隆隆石彻底没了" 
+    },
+    "Hold for 45 seconds": {
+      "translation": "45秒后道路开放" 
+    },
+    "Zombies will TP in 15 seconds": {
+      "translation": "僵尸将在15秒后传送" 
+    },
+    "Gym will open in 60 seconds": {
+      "translation": "道馆大门将在60秒后开启" 
+    },
+    "Gym is open": {
+      "translation": "道馆大门已开启" 
+    },
+    "Hold bridge for 30 seconds": {
+      "translation": "桥将在30秒后关闭" 
+    },
+    "Lt Surge is challenging you": {
+      "translation": "浪永中尉接受了你的挑战" 
+    },
+    "Lt Surge is picking Raichu": {
+      "translation": "浪永召唤了雷丘" 
+    },
+    "Raichu is using electro ball": {
+      "translation": "雷丘使用了雷电球" 
+    },
+    "Raichu is using Spark attack on RIGHT side": {
+      "translation": "雷丘在右半场使用了十万伏特" 
+    },
+    "Raichu is using Spark attack on LEFT side": {
+      "translation": "雷丘在左半场使用了十万伏特" 
+    },
+    "Raichu have been defeated": {
+      "translation": "雷丘被击败了" 
+    },
+    "Stage 3 complete": {
+      "translation": "第三关完成" 
+    },
+    "Map created by Bart": {
+      "translation": "地图作者:bart地图翻译:余清茗染@Fys" 
+    },
+    "Door will open in 15 seconds": {
+      "translation": "门将在15秒后开启" 
+    },
+    "Spawn teleport will activate in 20 seconds": {
+      "translation": "未进入门的玩家将在20秒后进行传送" 
+    },
+    "Hold for 45 seconds": {
+      "translation": "道路将在45秒后开启" 
+    },
+    "Guard door is open, fall back": {
+      "translation": "道路已开通,撤退" 
+    },
+    "Squirtle is attacking us": {
+      "translation": "是一只杰尼龟" 
+    },
+    "Squirtle is using surf": {
+      "translation": "杰尼龟正在攻击我们" 
+    },
+    "Zombies teleport in 25 seconds": {
+      "translation": "僵尸将在25秒后传送" 
+    },
+    "Hold for 50 seconds": {
+      "translation": "守住50秒" 
+    },
+    "Guard door is open, fall back": {
+      "translation": "道路已开通,撤退" 
+    },
+    "耿鬼隐藏在薰衣草镇,找到并杀死它,解除诅咒": {
+      "translation": "道路已开通,撤退" 
+    },
+    "Gengar used Curse": {
+      "translation": "耿鬼在背后使用诅咒" 
+    },
+    "Gengar have been defeated, hold for 20 seconds": {
+      "translation": "耿鬼已被击败,道路将在20秒后开通" 
+    },
+    "Zombies teleport in 20 seconds": {
+      "translation": "僵尸15秒后传送" 
+    },
+    "Hold for 40 seconds": {
+      "translation": "道路将在40秒后开放" 
+    },
+    "Gym opens in 20 seconds": {
+      "translation": "道馆将在20秒后开放" 
+    },
+    "Gym is open!": {
+      "translation": "道路已开通,撤退" 
+    },
+    "Hold for 30 seconds": {
+      "translation": "桥将在30秒后关闭" 
+    },
+    "Sabrina is challenging you": {
+      "translation": "萨布丽娜在挑战你" 
+    },
+    "Sabrina is picking Alakazam": {
+      "translation": "萨布丽娜召唤了胡地" 
+    },
+    "Alakazam is using psychic on LEFT side": {
+      "translation": "胡地在左半场使用了迷雾幻象" 
+    },
+    "Alakazam is using Shadowball, GET OUT OF THE MIDDLE": {
+      "translation": "胡地使用了暗影球" 
+    },
+    "Alakazam is using psychic on RIGHT side": {
+      "translation": "胡地在右半场使用了迷雾幻象" 
+    },
+    "Stage 4 completed": {
+      "translation": "最终关已通关" 
+    },
+    "More stages will be added in the future": {
+      "translation": "未来,我们会有更精彩的舞台" 
+    },
+    "Map is over, RTV!": {
+      "translation": "地图已全图通关,RTV RTV" 
+    }  
+  }
+  


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_pokemon_kanto_v1
## 为什么要增加/修改这个东西
补充了地图缺失的翻译
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
