### PR TITLE
修改地图翻译: ze_pokemon_kanto_v1

### DIFF
--- a/2001/sharp/data/translations/ze_pokemon_kanto_v1.jsonc
+++ b/2001/sharp/data/translations/ze_pokemon_kanto_v1.jsonc
@@ -283,8 +283,8 @@
   "Guard door is open, fall back": {
     "translation": "道路已开通,撤退" 
   },
-  "耿鬼隐藏在薰衣草镇,找到并杀死它,解除诅咒": {
-    "translation": "道路已开通,撤退" 
+  "Gengar have taken over lavender town, find and kill him": {
+    "translation": "耿鬼隐藏在薰衣草镇,找到并击败他" 
   },
   "Gengar used Curse": {
     "translation": "耿鬼在背后使用诅咒" 


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_pokemon_kanto_v1
## 为什么要增加/修改这个东西
修改地图错误翻译
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
