### PR TITLE
修改地图参数: ze_obf_filth

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obf_filth.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_filth.cfg
@@ -138,13 +138,13 @@ ze_weapons_spawn_hegrenade "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_molotov "1"
+ze_weapons_spawn_molotov "0"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_decoy "1"
+ze_weapons_spawn_decoy "0"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
@@ -191,13 +191,13 @@ ze_weapons_round_adrenaline "-1"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_reward_win_humans "17"
+ze_reward_win_humans "3"
 
 // 说  明: 伤害结算龙晶比例 (伤害/比例=龙晶) (伤害)
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_reward_damage "40000"
+ze_reward_damage "10000"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_obf_filth.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_filth.cfg
@@ -19,13 +19,13 @@
 // 最小值: 1
 // 最大值: 60
 // 类  型: float
-mp_timelimit "30.0"
+mp_timelimit "45.0"
 
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
 // 最大值: 60
 // 类  型: float
-mp_roundtime "15.0"
+mp_roundtime "60.0"
 
 
 ///
@@ -42,7 +42,7 @@ mcr_map_extend_times "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-vip_map_extend_times "1"
+vip_map_extend_times "2"
 
 
 ///
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "0.8"
 
 
 ///
@@ -138,37 +138,37 @@ ze_weapons_spawn_hegrenade "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_molotov "0"
+ze_weapons_spawn_molotov "1"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_decoy "0"
+ze_weapons_spawn_decoy "1"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "4"
+ze_weapons_round_hegrenade "12"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "2"
+ze_weapons_round_molotov "7"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_decoy "1"
+ze_weapons_round_decoy "5"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "1"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
@@ -180,7 +180,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "2"
+ze_weapons_round_adrenaline "-1"
 
 
 ///
@@ -191,13 +191,13 @@ ze_weapons_round_adrenaline "2"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_reward_win_humans "3"
+ze_reward_win_humans "17"
 
 // 说  明: 伤害结算龙晶比例 (伤害/比例=龙晶) (伤害)
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_reward_damage "10000"
+ze_reward_damage "40000"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obf_filth
## 为什么要增加/修改这个东西
因该张地图属OBJ系列长征火星地图,地图流程约38分钟,并且该张地图有多个地点人类需要分双路进行防守,压力可能较大,故增加三种手雷数量。目前CS2环境萌新偏多,需要更多地图时间来让萌新熟悉地图,故增加地图VIP投票和地图时长，并且该张地图有地图特色加血站,故删除血针,考虑该张地图流程过长,道具不能过于稀少,故增强僵尸击退至0.8击退。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
