### PR TITLE
修改地图参数: ze_pokemon_kanto_v1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_pokemon_kanto_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_pokemon_kanto_v1.cfg
@@ -19,7 +19,7 @@
 // 最小值: 1
 // 最大值: 60
 // 类  型: float
-mp_timelimit "25.0"
+mp_timelimit "40.0"
 
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
@@ -226,7 +226,7 @@ ze_skill_faster_speed "1.5"
 // 最小值: false
 // 最大值: true
 // 类  型: bool
-ms_flashlight_enabled "false"
+ms_flashlight_enabled "true"
 
 
 Echo Executed config for ze_pokemon_kanto_v1.


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_pokemon_kanto_v1
## 为什么要增加/修改这个东西
该地图已更新4关,原地图时长已不够支持通关全部流程。故增加地图时长。并且地图内有室内山洞等地形偏暗的环境,也将手电筒一并打开。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
