### PR TITLE
修改地图参数: ze_obj_rampage_v1_2

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obj_rampage_v1_2.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_rampage_v1_2.cfg
@@ -42,7 +42,7 @@ mcr_map_extend_times "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-vip_map_extend_times "1"
+vip_map_extend_times "2"
 
 
 ///
@@ -53,7 +53,7 @@ vip_map_extend_times "1"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "0.5"
+sv_falldamage_scale "0"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_rampage_v1_2
## 为什么要增加/修改这个东西
该图存在摔伤问题，会导致在外场阶段人类跳悬崖到二楼和从二楼防守撤退跳到一楼会出现摔死的情况，导致人类无法专心守点，故申请关闭摔伤，以及加个v延长
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
