### PR TITLE
修改地图参数: ze_obf_filth

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obf_filth.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_filth.cfg
@@ -138,13 +138,13 @@ ze_weapons_spawn_hegrenade "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_molotov "0"
+ze_weapons_spawn_molotov "1"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_decoy "0"
+ze_weapons_spawn_decoy "1"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
@@ -191,13 +191,13 @@ ze_weapons_round_adrenaline "-1"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_reward_win_humans "3"
+ze_reward_win_humans "17"
 
 // 说  明: 伤害结算龙晶比例 (伤害/比例=龙晶) (伤害)
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_reward_damage "10000"
+ze_reward_damage "40000"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obf_filth
## 为什么要增加/修改这个东西
长征类地图，守点时间长且难度高，调整龙晶获得比例与obj_rampage一致，稍调整人类初始道具数量以便萌新多不能及时购买道具的问题。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
