### PR TITLE
修改地图数据: ze_multimaps

### DIFF
--- a/2001/sharp/data/maps.json
+++ b/2001/sharp/data/maps.json
@@ -980,7 +980,7 @@
     "refund": 0.5
   },
   "ze_celestial_ops": {
-    "description": "天堂",
+    "description": "破碎末世",
     "tier": 2,
     "certainTimes": [-1],
     "price": 300,
@@ -1070,7 +1070,7 @@
     "refund": 0.5
   },
   "ze_forius_just_run_p": {
-    "description": "福里乌斯",
+    "description": "别打油桶",
     "tier": 2,
     "certainTimes": [-1],
     "price": 300,
@@ -1090,7 +1090,7 @@
     "refund": 0.5
   },
   "ze_inboxed_p": {
-    "description": "收件箱",
+    "description": "身法菜鸡的噩梦",
     "tier": 2,
     "certainTimes": [-1],
     "price": 300,
@@ -1130,7 +1130,7 @@
     "refund": 0.5
   },
   "ze_surf_okitsu_shonyudo": {
-    "description": "御津商道",
+    "description": "钟乳洞滑翔",
     "tier": 2,
     "certainTimes": [-1],
     "price": 300,
@@ -1146,21 +1146,21 @@
     "price": 300,
     "cooldown": 30,
     "nomination": false,
-    "admin": false,
+    "admin": true,
     "refund": 0.5
   },
   "ze_ffvii_fako_reactor": {
-    "description": "法科反应堆",
+    "description": "fako炉",
     "tier": 1,
     "certainTimes": [-1],
     "price": 300,
     "cooldown": 30,
     "nomination": false,
-    "admin": false,
+    "admin": true,
     "refund": 0.5
   },
   "ze_emerald": {
-    "description": "绿宝石",
+    "description": "翡翠之心",
     "tier": 1,
     "certainTimes": [-1],
     "price": 300,
@@ -1210,7 +1210,7 @@
     "refund": 0.5
   },
   "ze_mabinogi_f4_1_cs2": {
-    "description": "马比诺吉",
+    "description": "洛奇历险记",
     "tier": 1,
     "certainTimes": [-1],
     "price": 300,


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_multimaps
## 为什么要增加/修改这个东西
调整部分机翻地图名与csgo一致。由于goober制作的图内含有非常多的油桶（几乎为恶搞作），炸服概率大，且"ze_goobers_basement"存在push问题无法通关，故申请暂时限制地图。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
