### PR TITLE
修改地图参数: ze_starwars_v2fix

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_starwars_v2fix.cfg
+++ b/2001/csgo/cfg/map-configs/ze_starwars_v2fix.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "0.8"
 
 
 


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_starwars_v2fix
## 为什么要增加/修改这个东西
该地图因人类击退过于强大，神器溢出，道具过多，又因该地图测路在cs2中被删除导致僵尸无法正常与人类对抗，失去平衡，导致大多数变僵尸的玩家摆烂。故降低一点僵尸击退以方便双方公平抗争。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
