### PR TITLE
修改地图参数: ze_eizures_b1_1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_eizures_b1_1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_eizures_b1_1.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "0.6"
 
 
 
@@ -192,13 +192,13 @@ ze_weapons_round_adrenaline "2"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_reward_win_humans "3"
+ze_reward_win_humans "17"
 
 // 说  明: 伤害结算龙晶比例 (伤害/比例=龙晶) (伤害)
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_reward_damage "10000"
+ze_reward_damage "40000"
 
 
 ///
@@ -226,7 +226,7 @@ ze_skill_faster_speed "1.5"
 // 最小值: false
 // 最大值: true
 // 类  型: bool
-ms_flashlight_enabled "false"
+ms_flashlight_enabled "true"
 
 
 Echo Executed config for ze_eizures_b1_1.


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_eizures_b1_1
## 为什么要增加/修改这个东西
地图本身较为困难,在刚部署此地图时玩家大多不熟悉地图,所以通关较为困难,但是随着时间推移,该地图已经逐渐成为烂分图,原地图击退参数已经不适应于当前环境,故削弱僵尸击退,提高难度, 并且通关奖励跟地图难度不成正比,也将地图基础通关奖励和伤害奖励提高,该地图有室内管道等黑暗地形,也将手电筒一并打开。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
