### PR TITLE
修改地图参数: ze_obj_rampage_v1_2

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obj_rampage_v1_2.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_rampage_v1_2.cfg
@@ -122,7 +122,7 @@ ze_cash_round_start "8000"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.8"
+ze_cash_damage_zombie "0.7"
 
 
 ///
@@ -145,7 +145,7 @@ ze_weapons_spawn_molotov "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_decoy "1"
+ze_weapons_spawn_decoy "0"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
@@ -175,7 +175,7 @@ ze_weapons_round_flash "1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_smoke "1"
+ze_weapons_round_smoke "-1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_rampage_v1_2
## 为什么要增加/修改这个东西
由于内格夫伤害尚未平衡与csgo一致，且地图刷分点居多，金钱严重溢出，故调整打钱比。根据近日rampage实战表现，通关率偏高，僵尸体验较差，对抗性较低，故削弱人类击退数值。因cs2冰冻雷和屏障雷效果比csgo强，故尝试删除黑洞雷。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
