### PR TITLE
修改地图数据: ze_starwars_v2fix

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_starwars_v2fix.cfg
+++ b/2001/csgo/cfg/map-configs/ze_starwars_v2fix.cfg
@@ -198,7 +198,7 @@ ze_reward_win_humans "6"
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_reward_damage "8000"
+ze_reward_damage "20000"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_starwars_v2fix
## 为什么要增加/修改这个东西
地图伤害结算龙晶比例过低，且僵尸tp点多，出现一关内能获得30龙晶的情况，故作调整。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
