### PR TITLE
修改地图神器: ze_backrooms_deathbed_v1

### DIFF
--- a/2001/sharp/data/entWatch/ze_backrooms_deathbed_v1.jsonc
+++ b/2001/sharp/data/entWatch/ze_backrooms_deathbed_v1.jsonc
@@ -28,7 +28,7 @@
     "maxUses": 1,
     "team": 3,
     "knife": false,
-    "mode": 3,
+    "mode": 1,
     "count": 1
   },
   {
@@ -39,7 +39,7 @@
     "maxUses": 1,
     "team": 3,
     "knife": false,
-    "mode": 3,
+    "mode": 1,
     "count": 1
   }
 ]

--- a/2001/sharp/data/entWatch/ze_backrooms_deathbed_v1.jsonc
+++ b/2001/sharp/data/entWatch/ze_backrooms_deathbed_v1.jsonc
@@ -26,20 +26,22 @@
     "buttonClass": "func_button",
     "hammerId": "5687",
     "maxUses": 1,
+    "cooldown": 1,
     "team": 3,
     "knife": false,
-    "mode": 1,
+    "mode": 2,
     "count": 1
   },
   {
     "name": "手电筒2",
     "shortName": "闪",
     "buttonClass": "func_button",
-    "hammerId": "5709",
+    "hammerId": "5687",
     "maxUses": 1,
+    "cooldown": 1,
     "team": 3,
     "knife": false,
-    "mode": 1,
+    "mode": 2,
     "count": 1
   }
 ]


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_backrooms_deathbed_v1
## 为什么要增加/修改这个东西
手电筒神器设定为：使用counter显示电量，可自由开关手电筒，且耗尽hitmin时进入cd充电，充电结束后可正常使用。目前神器类型为“次数型”导致手电筒仅能使用一次，故暂时调整神器类型。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
