### PR TITLE
修改地图参数: ze_obf_npst_v1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obf_npst_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_npst_v1.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "0.8"
 
 
 
@@ -122,7 +122,7 @@ ze_cash_round_start "5000"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.8"
+ze_cash_damage_zombie "0.7"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obf_npst_v1
## 为什么要增加/修改这个东西
开荒期已过，且目前通关率较高，为保证地图对抗平衡性，适当削弱人类击退值。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
