### PR TITLE
修改地图参数: ze_obf_filth_v1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obf_filth_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_filth_v1.cfg
@@ -230,7 +230,7 @@ ze_skill_faster_speed "1.5"
 // 最小值: 30.0
 // 最大值: 1000.0
 // 类  型: float
-ze_skill_blader_damage "48.0"
+ze_skill_blader_damage "30.0"
 
 // 说  明: 恶魔技能连锁次数 (次)
 // 最小值: 1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obf_filth_v1
## 为什么要增加/修改这个东西
因开局僵尸刀锋超过4把的情况下，有概率击杀部分人类且较难躲避，为保证游戏平衡性调整刀锋僵尸技能伤害。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
