### PR TITLE
修改地图参数: ze_minecraft_sakura

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_minecraft_sakura.cfg
+++ b/2001/csgo/cfg/map-configs/ze_minecraft_sakura.cfg
@@ -36,13 +36,13 @@ mp_roundtime "15.0"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-mcr_map_extend_times "1"
+mcr_map_extend_times "0"
 
 // 说  明: VIP延长投票 (次)
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-vip_map_extend_times "1"
+vip_map_extend_times "0"
 
 
 ///
@@ -191,7 +191,7 @@ ze_rank_win_humans "3"
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_rank_damage "10000"
+ze_rank_damage "25000"
 
 
 ///
@@ -208,7 +208,7 @@ ze_reward_win_humans "3"
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_reward_damage "10000"
+ze_reward_damage "25000"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_minecraft_sakura
## 为什么要增加/修改这个东西
该图为刷分咸鱼图，自打法成型后人类基本全程刷尸笼，故调整伤害换算的龙晶与云点比例，同时削减地图V延和ext
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
