### PR TITLE
修改地图参数: ze_k19_escape_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_k19_escape_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_k19_escape_p.cfg
@@ -138,7 +138,7 @@ ze_weapons_spawn_molotov "0"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_decoy "1"
+ze_weapons_spawn_decoy "0"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_k19_escape_p
## 为什么要增加/修改这个东西
玩家开局丢冰卖人,因为丢冰人数过多无法精准找到卖人玩家追责且地图开局并不依赖初始冰冻弹守点,故申请删除地图CT方初始冰冻弹
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
