### PR TITLE
修改地图数据: ze_siberia_1990_p

### DIFF
--- a/2001/sharp/data/maps.json
+++ b/2001/sharp/data/maps.json
@@ -1210,7 +1210,7 @@
     "price": 300,
     "cooldown": 30,
     "nomination": false,
-    "admin": false
+    "admin": true
   },
   "ze_skygarden": {
     "certainTimes": [-1],


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_siberia_1990_p
## 为什么要增加/修改这个东西
该图有较为严重的闪退BUG，在山洞路按C4的地方，会导致游戏直接闪退，并且强制STEAM验证游戏完整性，玩家最后无法正常回到服务器导致鬼服，故申请锁图，直至BUG修复完成后开放
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
