### PR TITLE
修改地图参数: ze_surf_danger_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_surf_danger_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_surf_danger_p.cfg
@@ -185,13 +185,13 @@ ze_weapons_round_adrenaline "2"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_rank_win_humans "3"
+ze_rank_win_humans "5"
 
 // 说  明: 伤害结算云点比例 (伤害/比例=云点) (伤害)
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_rank_damage "10000"
+ze_rank_damage "50000"
 
 
 ///
@@ -202,13 +202,13 @@ ze_rank_damage "10000"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_reward_win_humans "3"
+ze_reward_win_humans "5"
 
 // 说  明: 伤害结算龙晶比例 (伤害/比例=龙晶) (伤害)
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_reward_damage "10000"
+ze_reward_damage "50000"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_surf_danger_p
## 为什么要增加/修改这个东西
和k19情况一样，老司机疯狂刷分，正常游玩的萌新玩家伤害无法满足最低门槛，经常误判为划水摸鱼。故提高基础奖励，削弱伤害转换云点和龙晶值。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
