### PR TITLE
修改地图参数: ze_hydroponic_garden

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_hydroponic_garden.cfg
+++ b/2001/csgo/cfg/map-configs/ze_hydroponic_garden.cfg
@@ -185,7 +185,7 @@ ze_weapons_round_adrenaline "2"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_rank_win_humans "8"
+ze_rank_win_humans "14"
 
 // 说  明: 伤害结算云点比例 (伤害/比例=云点) (伤害)
 // 最小值: 6000
@@ -202,7 +202,7 @@ ze_rank_damage "10000"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_reward_win_humans "10"
+ze_reward_win_humans "12"
 
 // 说  明: 伤害结算龙晶比例 (伤害/比例=龙晶) (伤害)
 // 最小值: 6000
@@ -243,7 +243,7 @@ ze_skill_deimos_amount "5"
 // 最小值: 1
 // 最大值: 100
 // 类  型: int32
-ze_skill_yaksha_damage "2"
+ze_skill_yaksha_damage "1"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_hydroponic_garden
## 为什么要增加/修改这个东西
调整地图通关奖励，同时由于地图NPC较多，掉血点多,且BOSS房不会回血，故削弱僵尸技能强度平衡地图
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
