### PR TITLE
修改地图参数: ze_visualizer

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_visualizer.cfg
+++ b/2001/csgo/cfg/map-configs/ze_visualizer.cfg
@@ -19,7 +19,7 @@
 // 最小值: 1
 // 最大值: 60
 // 类  型: float
-mp_timelimit "50.0"
+mp_timelimit "55.0"
 
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
@@ -243,7 +243,7 @@ ze_skill_deimos_amount "5"
 // 最小值: 1
 // 最大值: 100
 // 类  型: int32
-ze_skill_yaksha_damage "2"
+ze_skill_yaksha_damage "1"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_visualizer
## 为什么要增加/修改这个东西
地图为6关，且每关时间流程较长，为确保玩家能正常时间通关，故增加地图时间.同时由于地图NPC较多，掉血点多,且BOSS房不会回血，故削弱僵尸技能强度平衡地图
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
