### PR TITLE
修改地图数据: ze_basic_geometric

### DIFF
--- a/2001/sharp/data/maps.json
+++ b/2001/sharp/data/maps.json
@@ -156,9 +156,9 @@
   },
   "ze_basic_geometric": {
     "certainTimes": [-1],
-    "price": 300,
+    "price": 500,
     "cooldown": 80,
-    "nomination": false,
+    "nomination": true,
     "admin": false
   },
   "ze_bathroom": {


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_basic_geometric
## 为什么要增加/修改这个东西
地图难度较大，极易选出来后没人带或难带导致鬼服，因此将地图改为仅预定，同时增加预定地图龙晶数量
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
