### PR TITLE
修改地图参数: ze_basic_geometric

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_basic_geometric.cfg
+++ b/2001/csgo/cfg/map-configs/ze_basic_geometric.cfg
@@ -19,7 +19,7 @@
 // 最小值: 1
 // 最大值: 60
 // 类  型: float
-mp_timelimit "35.0"
+mp_timelimit "40.0"
 
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.2"
 
 
 ///
@@ -185,7 +185,7 @@ ze_weapons_round_adrenaline "2"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_rank_win_humans "3"
+ze_rank_win_humans "10"
 
 // 说  明: 伤害结算云点比例 (伤害/比例=云点) (伤害)
 // 最小值: 6000
@@ -202,7 +202,7 @@ ze_rank_damage "10000"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_reward_win_humans "3"
+ze_reward_win_humans "8"
 
 // 说  明: 伤害结算龙晶比例 (伤害/比例=龙晶) (伤害)
 // 最小值: 6000


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_basic_geometric
## 为什么要增加/修改这个东西
调整地图通关奖励，同时由于地图难度较高，普通参数基本无法通关，故申请增加地图击退已平衡地图难度
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
