### PR TITLE
修改地图参数: ze_silent_hill_2_illusion

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_silent_hill_2_illusion.cfg
+++ b/2001/csgo/cfg/map-configs/ze_silent_hill_2_illusion.cfg
@@ -191,7 +191,7 @@ ze_rank_win_humans "8"
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_rank_damage "10000"
+ze_rank_damage "20000"
 
 
 ///
@@ -208,7 +208,7 @@ ze_reward_win_humans "6"
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_reward_damage "10000"
+ze_reward_damage "20000"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_silent_hill_2_illusion
## 为什么要增加/修改这个东西
该图刷分点较多，且地图较为简单通关，故上调龙晶/云点伤害兑换比例平衡地图
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
