### PR TITLE
修改地图翻译: ze_ffvii_mako_reactor_v5_3

### DIFF
--- a/2001/sharp/data/translations/ze_ffvii_mako_reactor_v5_3.jsonc
+++ b/2001/sharp/data/translations/ze_ffvii_mako_reactor_v5_3.jsonc
@@ -35,7 +35,7 @@
     "translation": "**  一名玩家获得了治疗神器 **"
   },
   "** BAHAMUT IS DEAD ** KEEP RUNNING **": {
-    "translation": "** 巴哈姆特已死-往上跑! **"
+    "translation": "** 巴哈姆特已死-快跑! **"
   },
   "**** MAP BY: Hannibal[SPA] (Rafuron) ****": {
     "translation": "**** 地图作者: Hannibal[SPA] (Rafuron) 地图翻译:小妖梦@风云社 ****"
@@ -59,7 +59,7 @@
     "translation": "** 我们已经到达魔光炉的核心了  ...**"
   },
   "** ... Cloud is planting the bomb **": {
-    "translation": "** ... 正在安放炸弹,是时候该结束一切了! **"
+    "translation": "** ... 正在安放炸弹,是时候结束这一切了! **"
   },
   "** Bomb has been planted  **  Run **": {
     "translation": "** 炸弹已被安放-快走! **"
@@ -194,7 +194,7 @@
     "translation": "**门将在30秒后打开**"
   },
   "** BAHAMUT IS CASTING ** PREPARE YOURSELF **": {
-    "translation": "** 做好准备迎接巴哈姆特 **"
+    "translation": "** 巴哈姆特准备施放新一轮技能 **"
   },
   "** BAHAMUT HAS CAST FIRE! **": {
     "translation": "** 巴哈姆特正在施放火魔法! **"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffvii_mako_reactor_v5_3
## 为什么要增加/修改这个东西
修改地图翻译
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
