### PR TITLE
修改地图参数: ze_purification_a1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_purification_a1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_purification_a1.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.1"
 
 
 ///
@@ -191,7 +191,7 @@ ze_rank_win_humans "10"
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_rank_damage "10000"
+ze_rank_damage "15000"
 
 
 ///
@@ -208,7 +208,7 @@ ze_reward_win_humans "8"
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_reward_damage "10000"
+ze_reward_damage "15000"
 
 
 ///

--- a/2001/sharp/data/translations/ze_ffxii_westersand_v7_t.jsonc
+++ b/2001/sharp/data/translations/ze_ffxii_westersand_v7_t.jsonc
@@ -100,7 +100,7 @@
     "translation": "** 地图作者:SLAYERDRAGON  地图汉化:小妖梦@风云社**"
   },
   "** ZM JAIL OPEN **": {
-    "translation": "** 尸笼已开,你们打的太慢了! **"
+    "translation": "** 尸笼开了,在第二道出口处防守僵尸! **"
   },
   "** The airship reactors are going to explode!! **": {
     "translation": "** 飞船的反应装置要爆炸了!! **"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_purification_a1
## 为什么要增加/修改这个东西
前几次击退大改，导致部分地图未能适应，且地图守点难度较大，故调整击退和云点龙晶比例已确保玩家正常通关
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
