### PR TITLE
修改地图参数: ze_offliner

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_offliner.cfg
+++ b/2001/csgo/cfg/map-configs/ze_offliner.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.1"
 
 
 ///
@@ -132,7 +132,7 @@ ze_weapons_spawn_hegrenade "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_molotov "0"
+ze_weapons_spawn_molotov "1"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
@@ -243,7 +243,7 @@ ze_skill_deimos_amount "5"
 // 最小值: 1
 // 最大值: 100
 // 类  型: int32
-ze_skill_yaksha_damage "2"
+ze_skill_yaksha_damage "1"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_offliner
## 为什么要增加/修改这个东西
地图守点难度较大，导致大多数玩家已经遗弃地图，且boss房难度较大,BOSS房不回血 僵尸极易使用刀锋反伤将人类团灭，故将击退参数提高以及削弱赤鬼僵尸平衡地图确保能正常通关
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
