### PR TITLE
修改地图参数: ze_lightnight_v1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_lightnight_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_lightnight_v1.cfg
@@ -132,7 +132,7 @@ ze_weapons_spawn_hegrenade "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_molotov "0"
+ze_weapons_spawn_molotov "1"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
@@ -237,7 +237,7 @@ ze_skill_blader_damage "48.0"
 // 最小值: 1
 // 最大值: 10
 // 类  型: int32
-ze_skill_deimos_amount "5"
+ze_skill_deimos_amount "1"
 
 // 说  明: 赤焰技能伤害 (次)
 // 最小值: 1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_lightnight_v1
## 为什么要增加/修改这个东西
地图最后一个点存活人数较少，煤气罐对幸存人数的道具威胁较大，导致地图一直没有正常首通过，故申请削弱僵尸技能强度确保玩家能够正常通关
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
