### PR TITLE
修改地图参数: ze_slender_escape_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_slender_escape_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_slender_escape_p.cfg
@@ -19,7 +19,7 @@
 // 最小值: 1
 // 最大值: 60
 // 类  型: float
-mp_timelimit "50.0"
+mp_timelimit "45.0"
 
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
@@ -36,7 +36,7 @@ mp_roundtime "20"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-mcr_map_extend_times "1"
+mcr_map_extend_times "0"
 
 // 说  明: VIP延长投票 (次)
 // 最小值: 0
@@ -185,13 +185,13 @@ ze_weapons_round_adrenaline "2"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_rank_win_humans "10"
+ze_rank_win_humans "8"
 
 // 说  明: 伤害结算云点比例 (伤害/比例=云点) (伤害)
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_rank_damage "15000"
+ze_rank_damage "6000"
 
 
 ///
@@ -202,13 +202,13 @@ ze_rank_damage "15000"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_reward_win_humans "8"
+ze_reward_win_humans "6"
 
 // 说  明: 伤害结算龙晶比例 (伤害/比例=龙晶) (伤害)
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_reward_damage "15000"
+ze_reward_damage "6000"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_slender_escape_p
## 为什么要增加/修改这个东西
地图关卡多为小游戏关，且小游戏关流程较短，人类方赚取龙晶和云点速度太快,导致没人愿意玩流程难度最长的最终关.为确保地图之间平衡，故削弱地图通关收益，减少伤害结算比例鼓励玩家挑战最终关,并减少地图时间以防止地图一直被玩至鬼服
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
