### PR TITLE
修改地图参数: ze_inboxed_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_inboxed_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_inboxed_p.cfg
@@ -219,7 +219,7 @@ ze_reward_damage "10000"
 // 最小值: 150.0
 // 最大值: 2000.0
 // 类  型: float
-ze_skill_hunter_power "160.0"
+ze_skill_hunter_power "150.0"
 
 // 说  明: 加速Boost (%)
 // 最小值: 1.05


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_inboxed_p
## 为什么要增加/修改这个东西
该地图 闪灵越地形超车 人类都未到达点位 僵尸先一步到达，进行超车,并且玩家大多对此觉得没问题，申请将闪灵击退调到最小指。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
