### PR TITLE
修改地图参数: ze_ffvii_mako_reactor_v6_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_ffvii_mako_reactor_v6_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffvii_mako_reactor_v6_p.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "2.0"
+sv_falldamage_scale "0"
 
 
 ///
@@ -82,7 +82,7 @@ ze_infect_teleport_to_spawn "true"
 // 最小值: 10
 // 最大值: 90
 // 类  型: int32
-ze_infect_mother_spawn_time "27"
+ze_infect_mother_spawn_time "20"
 
 
 ///
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.2"
 
 
 ///
@@ -144,13 +144,13 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "2"
+ze_weapons_round_hegrenade "5"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "-1"
+ze_weapons_round_molotov "1"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffvii_mako_reactor_v6_p
## 为什么要增加/修改这个东西
地图摔伤过于严重，导致僵尸能不吃摔伤超车，且人类下完炉子往往活不过10个，故参考CSGO调整地图参数确保地图能够正常游玩
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
