### PR TITLE
补充地图神器: ze_urban_laby_of_death_p

### DIFF
--- a/2001/sharp/data/entWatch/ze_urban_laby_of_death_p.jsonc
+++ b/2001/sharp/data/entWatch/ze_urban_laby_of_death_p.jsonc
@@ -1,0 +1,148 @@
+// entWatch configuration file generator.
+// EntWatch Version v21
+// Copyright 2024 Kyle 'Kxnrl' Frankiss.
+// https://github.com/Kxnrl
+
+  // 可用字段:
+  // name         (string) -> 名字
+  // shortName    (string) -> 计分板短名
+  // buttonClass  (string) -> 按钮的classname
+  // hammerId     (string) -> 武器HammerId
+  // triggerId    (string) -> 触发器HammerId
+  // containerId  (string) -> 容器HammerId
+  // maxUses      (int)    -> 最大使用次数
+  // initCooldown (int)    -> 初始化冷却时间
+  // cooldown     (int)    -> 冷却时间
+  // team         (int)    -> 3 = 人类, 2 = 僵尸
+  // knife        (bool)   -> 是否是匕首, 填错捡不起来
+  // soulEvent    (string) -> 灵魂绑定IO
+  // mode         (int)    -> 0 = 无按钮, 1 = 仅提示, 2 = CD型, 3 = 次数型, 4 = 次数+CD型, 5 = 使用一定次数后进入CD型, 6 = 燃料型(OnHitMin), 7 = 燃料型(OnHitMax), 8 = 计数型(类似狮子王MiniCanon)
+  // count        (int)    -> 神器个数
+
+[
+  {
+    "name": "阻滞",
+    "shortName": "阻滞",
+    "buttonClass": "func_button",
+    "hammerId": "9159",
+    "triggerId": ["9157"],
+    "cooldown": 0,
+    "team": 2,
+    "knife": true,
+    "mode": 1,
+    "count": 1
+  },
+  {
+    "name": "暴风吸入",
+    "shortName": "吸吸",
+    "buttonClass": "func_button",
+    "hammerId": "9174",
+    "triggerId": ["9172"],
+    "cooldown": 70,
+    "team": 2,
+    "knife": true,
+    "mode": 2,
+    "count": 1
+  },
+  {
+    "name": "狂暴",
+    "shortName": "狂暴",
+    "buttonClass": "func_button",
+    "hammerId": "9186",
+    "triggerId": ["9184"],
+    "cooldown": 66,
+    "team": 2,
+    "knife": true,
+    "mode": 2,
+    "count": 1
+  },
+  {
+    "name": "治疗",
+    "shortName": "治疗",
+    "buttonClass": "func_button",
+    "hammerId": "9201",
+    "triggerId": ["9199"],
+    "cooldown": 68,
+    "team": 2,
+    "knife": true,
+    "mode": 2,
+    "count": 1
+  },
+  {
+    "name": "炸药",
+    "shortName": "炸药",
+    "buttonClass": "func_button",
+    "hammerId": "1904",
+    "cooldown": 0,
+    "team": 3,
+    "knife": true,
+    "mode": 1,
+    "count": 1
+  },
+  {
+    "name": "背包",
+    "shortName": "背包",
+    "buttonClass": "func_button",
+    "hammerId": "8075",
+    "cooldown": 0,
+    "team": 3,
+    "knife": true,
+    "mode": 1,
+    "count": 1
+  },
+  {
+    "name": "冰冻",
+    "shortName": "冰冻",
+    "buttonClass": "func_button",
+    "hammerId": "9031",
+    "cooldown": 68,
+    "team": 3,
+    "knife": true,
+    "mode": 2,
+    "count": 1
+  },
+  {
+    "name": "地雷",
+    "shortName": "地雷",
+    "buttonClass": "func_button",
+    "hammerId": "9049",
+    "cooldown": 0,
+    "team": 3,
+    "knife": true,
+    "mode": 1,
+    "count": 1
+  },
+  {
+    "name": "火焰喷射器",
+    "shortName": "喷火",
+    "buttonClass": "func_button",
+    "hammerId": "9087",
+    "cooldown": 0,
+    "team": 3,
+    "knife": true,
+    "mode": 1,
+    "count": 1
+  },
+  {
+    "name": "弹药",
+    "shortName": "补给",
+    "buttonClass": "func_button",
+    "hammerId": "9099",
+    "cooldown": 0,
+    "team": 3,
+    "knife": true,
+    "mode": 1,
+    "count": 1
+  },
+  {
+    "name": "加速",
+    "shortName": "加速",
+    "buttonClass": "func_button",
+    "hammerId": "9126",
+    "cooldown": 100,
+    "team": 3,
+    "knife": true,
+    "mode": 2,
+    "count": 5
+  }
+]


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_urban_laby_of_death_p
## 为什么要增加/修改这个东西
ze_urban_laby_of_death_p entwatch部分
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
