### PR TITLE
修改地图参数: ze_xenovation

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_xenovation.cfg
+++ b/2001/csgo/cfg/map-configs/ze_xenovation.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.1"
+ze_knockback_scale "1.3"
 
 
 ///
@@ -185,7 +185,7 @@ ze_weapons_round_adrenaline "3"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_rank_win_humans "12"
+ze_rank_win_humans "15"
 
 // 说  明: 伤害结算云点比例 (伤害/比例=云点) (伤害)
 // 最小值: 6000
@@ -202,7 +202,7 @@ ze_rank_damage "15000"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_reward_win_humans "8"
+ze_reward_win_humans "12"
 
 // 说  明: 伤害结算龙晶比例 (伤害/比例=龙晶) (伤害)
 // 最小值: 6000


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_xenovation
## 为什么要增加/修改这个东西
地图为长征类型 守点宽口较多 且僵尸神器强力导致地图过关困难 故增加地图击退比以及地图奖励鼓励玩家过图
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
