### PR TITLE
修改地图参数: ze_purification_a1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_purification_a1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_purification_a1.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.3"
+ze_knockback_scale "1.4"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_purification_a1
## 为什么要增加/修改这个东西
地图分路居多 守点时间长 且地图机制对人类非常不利 地图通关率较低 故调高击退比以便于玩家正常通关
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
