### PR TITLE
修改地图参数: ze_predator_ultimate_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_predator_ultimate_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_predator_ultimate_p.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "0.5"
+sv_falldamage_scale "0.0"
 
 
 ///
@@ -104,12 +104,12 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.2"
 
 
 ///
 /// Economy
-///
+///   
 
 // 说  明: 伤害与金钱转化比例 (%)
 // 最小值: 0.1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_predator_ultimate_p
## 为什么要增加/修改这个东西
铁血前两关瀑布地方 原CSGO可滑翔并且通过水上加速通过,但是现在由于CS2没有水上加速了,而且在瀑布末端会有摔伤,导致人类非死即伤,并且僵尸闪灵可通过大飞轻松超越人类,而且现在铁血是冷门地图,萌新游玩也少,前两关通关率过于低下,故想将摔伤改为0.0并且提高0.2击退。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
