### PR TITLE
修改地图参数: ze_fapescape_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_fapescape_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_fapescape_p.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "0.8"
 
 
 ///
@@ -144,7 +144,7 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "7"
+ze_weapons_round_hegrenade "5"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "3"
+ze_weapons_round_adrenaline "2"
 
 
 ///
@@ -191,7 +191,7 @@ ze_rank_win_humans "12"
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_rank_damage "15000"
+ze_rank_damage "20000"
 
 
 ///
@@ -208,7 +208,7 @@ ze_reward_win_humans "8"
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_reward_damage "15000"
+ze_reward_damage "20000"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_fapescape_p
## 为什么要增加/修改这个东西
因胜率过高，调整人类击退值和地图收益。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
