### PR TITLE
修改地图Boss: ze_obf_npst_v2

### DIFF
--- a/2001/sharp/data/bosses/ze_obf_npst_v2.jsonc
+++ b/2001/sharp/data/bosses/ze_obf_npst_v2.jsonc
@@ -29,7 +29,7 @@
     {
       "iterator": "Nihi_Hp_Counter_D",
       "hitbox": "Nihilanth_HitBox_Head",
-      "display": "Head"
+      "display": "Nihi:Head"
     },
     {
       "iterator": "Sniper_Counter",
@@ -65,11 +65,10 @@
       "iterator": "Nihi_Crystal_C_Counter",
       "hitbox": "Nihi_Crystal_C_Phy",
       "display": "CryStal:C"
-    }
-  ],
-  "Monsters": [
+    },
     {
-      "identity": "31178",
+      "iterator": "barnacle_counter",
+      "hitbox": "barnacle_physbox",
       "display": "Barnacle"
     }
   ]

--- a/2001/sharp/data/bosses/ze_obf_npst_v2.jsonc
+++ b/2001/sharp/data/bosses/ze_obf_npst_v2.jsonc
@@ -50,21 +50,24 @@
       "iterator": "Nihi_Hp_Counter_C",
       "hitbox": "Nihilanth_HitBox_Main",
       "display": "Nihi:Phase3"
+    },
+    {
+      "iterator": "Nihi_Crystal_A_Counter",
+      "hitbox": "Nihi_Crystal_A_Phy",
+      "display": "CryStal:A"
+    },
+    {
+      "iterator": "Nihi_Crystal_B_Counter",
+      "hitbox": "Nihi_Crystal_B_Phy",
+      "display": "CryStal:B"
+    },
+    {
+      "iterator": "Nihi_Crystal_C_Counter",
+      "hitbox": "Nihi_Crystal_C_Phy",
+      "display": "CryStal:C"
     }
   ],
   "Monsters": [
-    {
-      "identity": "30852",
-      "display": "CryStal"
-    },
-    {
-      "identity": "30856",
-      "display": "CryStal"
-    },
-    {
-      "identity": "30858",
-      "display": "CryStal"
-    },
     {
       "identity": "31178",
       "display": "Barnacle"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obf_npst_v2
## 为什么要增加/修改这个东西
ze_obf_npst_v2 水晶藤壶准确显示Hp
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
