### PR TITLE
修改地图参数: ze_2049

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_2049.cfg
+++ b/2001/csgo/cfg/map-configs/ze_2049.cfg
@@ -185,7 +185,7 @@ ze_weapons_round_adrenaline "2"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_rank_win_humans "8"
+ze_rank_win_humans "12"
 
 // 说  明: 伤害结算云点比例 (伤害/比例=云点) (伤害)
 // 最小值: 6000
@@ -202,7 +202,7 @@ ze_rank_damage "8000"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_reward_win_humans "6"
+ze_reward_win_humans "8"
 
 // 说  明: 伤害结算龙晶比例 (伤害/比例=龙晶) (伤害)
 // 最小值: 6000

--- a/2001/csgo/cfg/map-configs/ze_2049.cfg
+++ b/2001/csgo/cfg/map-configs/ze_2049.cfg
@@ -19,7 +19,7 @@
 // 最小值: 1
 // 最大值: 60
 // 类  型: float
-mp_timelimit "30.0"
+mp_timelimit "40.0"
 
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
@@ -82,7 +82,7 @@ ze_infect_teleport_to_spawn "true"
 // 最小值: 10
 // 最大值: 90
 // 类  型: int32
-ze_infect_mother_spawn_time "15"
+ze_infect_mother_spawn_time "18"
 
 
 ///
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.1"
+ze_knockback_scale "1.2"
 
 
 ///
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "-1"
+ze_weapons_round_adrenaline "2"
 
 
 ///
@@ -237,7 +237,7 @@ ze_skill_blader_damage "38.0"
 // 最小值: 1
 // 最大值: 10
 // 类  型: int32
-ze_skill_deimos_amount "5"
+ze_skill_deimos_amount "2"
 
 // 说  明: 赤焰技能伤害 (次)
 // 最小值: 1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_2049
## 为什么要增加/修改这个东西
地图为新图 断口较多 分叉路守点难度较大 目前开荒参数太低导致过图较难 BOSS血量以及伤害高 没有血针的情况下及其容易掉人导致最后人数不够守点困难 故增加地图参数和血针以及削弱僵尸技能确保地图能够在开荒期间正常通关
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
