### PR TITLE
修改地图数据: ze_undead_shrine_p

### DIFF
--- a/2001/sharp/data/maps.json
+++ b/2001/sharp/data/maps.json
@@ -2216,7 +2216,7 @@
     "price": 500,
     "cooldown": 100,
     "nomination": true,
-    "admin": true
+    "admin": false
   },
   "ze_undertale_sans_final": {
     "certainTimes": [-1],

--- a/2001/sharp/data/rewards/ze_undead_shrine_p.jsonc
+++ b/2001/sharp/data/rewards/ze_undead_shrine_p.jsonc
@@ -12,9 +12,9 @@
 
 {
   "base": {
-    "rankPasses": 15,
+    "rankPasses": 22,
     "rankDamage": 18000,
-    "econPasses": 10,
+    "econPasses": 18,
     "econDamage": 20000
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_undead_shrine_p
## 为什么要增加/修改这个东西
地图现为1关制长守点地图，守点和触发难度偏高。且现无bug，可以正常游玩
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
