### PR TITLE
修改地图参数: ze_ffvii_mako_reactor_v6_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_ffvii_mako_reactor_v6_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffvii_mako_reactor_v6_p.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.2"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.0"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.6"
+ze_cash_damage_zombie "0.8"
 
 
 ///
@@ -144,7 +144,7 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "2"
+ze_weapons_round_hegrenade "5"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -191,7 +191,7 @@ ze_rank_win_humans "10"
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_rank_damage "18000"
+ze_rank_damage "13000"
 
 
 ///
@@ -208,7 +208,7 @@ ze_reward_win_humans "7"
 // 最小值: 6000
 // 最大值: 100000
 // 类  型: int32
-ze_reward_damage "20000"
+ze_reward_damage "15000"
 
 
 ///
@@ -225,7 +225,7 @@ ze_skill_hunter_power "160.0"
 // 最小值: 1.05
 // 最大值: 2.0
 // 类  型: float
-ze_skill_faster_speed "1.5"
+ze_skill_faster_speed "1.3"
 
 // 说  明: 刀锋技能伤害 (unit)
 // 最小值: 30.0

--- a/2001/csgo/cfg/map-configs/ze_ffvii_mako_reactor_v6_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffvii_mako_reactor_v6_p.cfg
@@ -82,7 +82,7 @@ ze_infect_teleport_to_spawn "true"
 // 最小值: 10
 // 最大值: 90
 // 类  型: int32
-ze_infect_mother_spawn_time "27"
+ze_infect_mother_spawn_time "15"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffvii_mako_reactor_v6_p
## 为什么要增加/修改这个东西
地图难度较高，调整人类基础参数，因地图根据关卡会强化僵尸地速，为尽量削弱僵尸双涡轮加速，削弱加速僵尸参数比例。此参数已经过实战测试。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
