### PR TITLE
修改地图翻译: ze_ffvii_mako_reactor_v5_3

### DIFF
--- a/2001/sharp/data/translations/ze_ffvii_mako_reactor_v5_3.jsonc
+++ b/2001/sharp/data/translations/ze_ffvii_mako_reactor_v5_3.jsonc
@@ -74,7 +74,7 @@
     "translation": "**保持火力!我们还不知道他会做什么! **"
   },
   "** EXPLOSION IN 145 SECONDS **": {
-    "translation": "** 距离魔光炉爆炸还剩一百四十五秒! **"
+    "translation": "** 距离魔光炉爆炸还剩145秒! **"
   },
   "**  10 SECONDS LEFT **": {
     "translation": "**  剩余10秒! **"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffvii_mako_reactor_v5_3
## 为什么要增加/修改这个东西
修正一处地图翻译错误导致倒计时无法正常显示。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
