### PR TITLE
修改地图参数: ze_minimal

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_minimal.cfg
+++ b/2001/csgo/cfg/map-configs/ze_minimal.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.3"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_minimal
## 为什么要增加/修改这个东西
该图为火星系列地图 守点分叉路居多 多为大宽口守点 且kz触发困难 需要人类方火力及其大才能坚守触发路回来 故申请调高击退平衡地图同时让这张地图能够正常开荒通关
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
