### PR TITLE
修改地图神器: ze_christmas_p

### DIFF
--- a/2001/sharp/data/entWatch/ze_christmas_p.jsonc
+++ b/2001/sharp/data/entWatch/ze_christmas_p.jsonc
@@ -37,7 +37,7 @@
     "shortName": "重力",
     "buttonClass": "func_physbox",
     "hammerId": "147",
-    "cooldown": 30,
+    "cooldown": 75,
     "team": 3,
     "knife": false,
     "mode": 2,


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_christmas_p

## 为什么要增加/修改这个东西
修复重力冷却时间的显示，正确值应为 75 秒。  
验证信息：  
路径：`maps/ze_christmas_p/entities/151#entitylumpname.vents_c`  
相关代码：  
- 第 135 行：`@OnPass Delay=75 Start [PR#]Item_Gravity_Model`  
- 第 136 行：`@OnPass Delay=75 Enable [PR#]gravity_relay`

## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.