### PR TITLE
修改地图数据: ze_sandstrom_cs2

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_sandstorm_cs2.cfg
+++ b/2001/csgo/cfg/map-configs/ze_sandstorm_cs2.cfg
@@ -19,7 +19,7 @@
 // 最小值: 1
 // 最大值: 60
 // 类  型: float
-mp_timelimit "40.0"
+mp_timelimit "60.0"
 
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
@@ -42,7 +42,7 @@ mcr_map_extend_times "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-vip_map_extend_times "2"
+vip_map_extend_times "1"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_sandstrom_cs2
## 为什么要增加/修改这个东西
地图初始时间较短，经常忘记拉延长导致最终关直接换图。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
