### PR TITLE
修改地图参数: ze_eizures_b2

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_eizures_b2.cfg
+++ b/2001/csgo/cfg/map-configs/ze_eizures_b2.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "0.9"
+ze_knockback_scale "1.0"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "0.9"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.6"
+ze_cash_damage_zombie "0.7"
 
 
 ///
@@ -144,7 +144,7 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "12"
+ze_weapons_round_hegrenade "15"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -156,7 +156,7 @@ ze_weapons_round_molotov "8"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_decoy "5"
+ze_weapons_round_decoy "7"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -225,7 +225,7 @@ ze_skill_hunter_power "160.0"
 // 最小值: 1.05
 // 最大值: 2.0
 // 类  型: float
-ze_skill_faster_speed "1.5"
+ze_skill_faster_speed "1.3"
 
 // 说  明: 刀锋技能伤害 (unit)
 // 最小值: 30.0
@@ -237,7 +237,7 @@ ze_skill_blader_damage "30.0"
 // 最小值: 1
 // 最大值: 10
 // 类  型: int32
-ze_skill_deimos_amount "5"
+ze_skill_deimos_amount "3"
 
 // 说  明: 赤焰技能伤害 (次)
 // 最小值: 1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_eizures_b2
## 为什么要增加/修改这个东西
根据最近通关率难以通关，人类撤退点较难，故调整人类基础参数；因地图地形对加速僵尸过于强大，削弱加速僵尸破点/追尾能力，恢复缴械僵尸正常数值
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
