### PR TITLE
修改地图Boss: ze_ffxii_westersand_v8

### DIFF
--- a/2001/sharp/data/bosses/ze_ffxii_westersand_v8.jsonc
+++ b/2001/sharp/data/bosses/ze_ffxii_westersand_v8.jsonc
@@ -43,5 +43,19 @@
       "hitbox": "Espers_Belias_Physbox",
       "display": "Belias"
     }
+  ],
+  "Monsters": [
+    {
+      "identity": "4393",
+      "display": "玛提乌斯"
+    },
+    {
+      "identity": "4389",
+      "display": "卡奥斯"
+    },
+    {
+      "identity": "4391",
+      "display": "贝利亚斯"
+    }
   ]
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffxii_westersand_v8
## 为什么要增加/修改这个东西
增加God关审判长大技能生成Boss的血量显示
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
