### PR TITLE
修改地图参数: ze_obj_void_v1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obj_void_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_void_v1.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.1"
+ze_knockback_scale "0.9"
 
 
 ///
@@ -144,19 +144,19 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "16"
+ze_weapons_round_hegrenade "12"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "8"
+ze_weapons_round_molotov "7"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_decoy "7"
+ze_weapons_round_decoy "5"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "6"
+ze_weapons_round_adrenaline "5"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_void_v1
## 为什么要增加/修改这个东西
已经过地图开荒测试后，平衡人类参数与ze_obj_rampage_v1_2对标。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
