### PR TITLE
修改地图参数: ze_pirates_port_royal

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_pirates_port_royal.cfg
+++ b/2001/csgo/cfg/map-configs/ze_pirates_port_royal.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.1"
+ze_knockback_scale "1.3"
 
 
 ///
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "0"
+ze_weapons_round_adrenaline "1"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
 ze_pirates_port_royal
## 为什么要增加/修改这个东西
由于第六关新增僵尸多条侧路,人类防守难度大大增加,现增加人类击退,以及增加一根可购买血针提升容错.
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
