### PR TITLE
修改地图Boss: ze_tyranny2

### DIFF
--- a/2001/sharp/data/bosses/ze_tyranny2.jsonc
+++ b/2001/sharp/data/bosses/ze_tyranny2.jsonc
@@ -115,6 +115,14 @@
     {
       "identity": "8341",
       "display": "下层木板"
+    },
+    {
+      "identity": "9567",
+      "display": "门神龙(hitbox)"
+    },
+    {
+      "identity": "9399",
+      "display": "暗黑破坏神(hitbox)"
     }
   ]
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_tyranny2
## 为什么要增加/修改这个东西
最后一关多个BOSS公用血量计数器导致无法显示血量，临时改为绑定hitbox提供命中反馈。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
