### PR TITLE
修改地图参数: ze_shroomforest_i

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_shroomforest_i.cfg
+++ b/2001/csgo/cfg/map-configs/ze_shroomforest_i.cfg
@@ -42,7 +42,7 @@ mcr_map_extend_times "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-vip_map_extend_times "1"
+vip_map_extend_times "0"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_shroomforest_i.cfg
+++ b/2001/csgo/cfg/map-configs/ze_shroomforest_i.cfg
@@ -36,13 +36,13 @@ mp_roundtime "15.0"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-mcr_map_extend_times "1"
+mcr_map_extend_times "0"
 
 // 说  明: VIP延长投票 (次)
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-vip_map_extend_times "0"
+vip_map_extend_times "1"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_shroomforest_i
## 为什么要增加/修改这个东西
为防止在选关关卡滥用地图调关,故将地图时间压缩至65分钟
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
