### PR TITLE
修改地图参数: ze_only_up

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_only_up.cfg
+++ b/2001/csgo/cfg/map-configs/ze_only_up.cfg
@@ -19,13 +19,13 @@
 // 最小值: 1
 // 最大值: 60
 // 类  型: float
-mp_timelimit "25.0"
+mp_timelimit "45.0"
 
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
 // 最大值: 60
 // 类  型: float
-mp_roundtime "15.0"
+mp_roundtime "40.0"
 
 
 ///
@@ -36,7 +36,7 @@ mp_roundtime "15.0"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-mcr_map_extend_times "1"
+mcr_map_extend_times "2"
 
 // 说  明: VIP延长投票 (次)
 // 最小值: 0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_only_up
## 为什么要增加/修改这个东西
调整地图的全局时间和单回合时间,并添加一个ext延长投票
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
