### PR TITLE
补充地图通关奖励: ze_nuclear_site_survie_by_gm

### DIFF
--- a/2001/sharp/configs/rewards/ze_nuclear_site_survie_by_gm.jsonc
+++ b/2001/sharp/configs/rewards/ze_nuclear_site_survie_by_gm.jsonc
@@ -1,0 +1,23 @@
+// Round Reward configuration file generator.
+// Reward Version v22
+// Copyright 2025 Kyle 'Kxnrl' Frankiss.
+// https://github.com/Kxnrl
+
+  // 可用字段:
+  // rankPasses (int)   -> 通关云点
+  // rankDamage (int)   -> 伤害结算云点比例
+  // rankIntern (float) -> 低保云点比例 (每分钟)
+  // econPasses (int)   -> 通关龙晶
+  // econDamage (int)   -> 伤害结算龙晶比例
+  // econIntern (float) -> 低保龙晶比例 (每分钟)
+
+{
+  "1": {
+    "rankPasses": 5,
+    "rankDamage": 30000,
+    "rankIntern": 0.4,
+    "econPasses": 4,
+    "econDamage": 35000,
+    "econIntern": 0.2
+  }
+}


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_nuclear_site_survie_by_gm
## 为什么要增加/修改这个东西
缺少地图奖励，特此增加
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
