### PR TITLE
补充地图通关奖励: ze_panic_escape_p

### DIFF
--- a/2001/sharp/configs/rewards/ze_panic_escape_p.jsonc
+++ b/2001/sharp/configs/rewards/ze_panic_escape_p.jsonc
@@ -13,11 +13,27 @@
 
 {
   "1": {
-    "rankPasses": 3,
-    "rankDamage": 12000,
-    "rankIntern": 0.4,
-    "econPasses": 2,
-    "econDamage": 15000,
+    "rankPasses": 4,
+    "rankDamage": 20000,
+    "rankIntern": 0.3,
+    "econPasses": 3,
+    "econDamage": 25000,
+    "econIntern": 0.2
+  },
+  "2": {
+    "rankPasses": 4,
+    "rankDamage": 20000,
+    "rankIntern": 0.3,
+    "econPasses": 3,
+    "econDamage": 25000,
+    "econIntern": 0.2
+  },
+  "3": {
+    "rankPasses": 5,
+    "rankDamage": 20000,
+    "rankIntern": 0.3,
+    "econPasses": 4,
+    "econDamage": 25000,
     "econIntern": 0.2
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_panic_escape_p
## 为什么要增加/修改这个东西
地图第二关与第三关缺少通关奖励
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
