### PR TITLE
修改地图参数: ze_20_seconds_v1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_20_seconds_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_20_seconds_v1.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.2"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.0"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.6"
+ze_cash_damage_zombie "0.7"
 
 
 ///
@@ -144,13 +144,13 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "4"
+ze_weapons_round_hegrenade "6"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "2"
+ze_weapons_round_molotov "3"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
@@ -185,7 +185,7 @@ ze_weapons_round_adrenaline "2"
 // 最小值: 0
 // 最大值: 50
 // 类  型: int32
-ze_rank_win_humans "3"
+ze_rank_win_humans "5"
 
 // 说  明: 伤害结算云点比例 (伤害/比例=云点) (伤害)
 // 最小值: 6000
@@ -219,13 +219,13 @@ ze_reward_damage "14000"
 // 最小值: 150.0
 // 最大值: 2000.0
 // 类  型: float
-ze_skill_hunter_power "160.0"
+ze_skill_hunter_power "150.0"
 
 // 说  明: 加速Boost (%)
 // 最小值: 1.05
 // 最大值: 2.0
 // 类  型: float
-ze_skill_faster_speed "1.5"
+ze_skill_faster_speed "1.3"
 
 // 说  明: 刀锋技能伤害 (unit)
 // 最小值: 30.0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_20_seconds_v1
## 为什么要增加/修改这个东西
因地图地形极其容易使加速僵尸和闪灵僵尸操作，且地图设计较简单但通关率相对较低，故增加人类基础参数，削弱加速和闪灵数值
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
