### PR TITLE
修复了刀剑中boss血条无法正常显示以及第五关boss无法击败的问题

### DIFF
--- a/2001/sharp/configs/bosses/ze_s_a_m.jsonc
+++ b/2001/sharp/configs/bosses/ze_s_a_m.jsonc
@@ -1,6 +1,6 @@
 // BossHP configuration file generator.
 // Boss Version v22
-// Copyright 2025 Kyle 'Kxnrl' Frankiss.
+// Copyright 2024 Kyle 'Kxnrl' Frankiss.
 // https://github.com/Kxnrl
 
   // 可用字段:
@@ -22,29 +22,44 @@
 {
   "Counters": [
     {
-      "iterator": "Troll_Hp_Counter",
+      "iterator": "Troll_Hp",
+      "count": "Troll_Hp_Counter",
+      "backup": "Troll_Hp_Get",
+      "increase": true,
       "hitbox": "Troll_Box",
-      "display": "Troll"
+      "display": "巨魔"
     },
     {
-      "iterator": "S2_Boss_Hp_Counter",
+      "iterator": "S2_Boss_Hp",
+      "count": "S2_Boss_Hp_Counter",
+      "backup": "S2_Boss_Hp_Get",
+      "increase": true,
       "hitbox": "S2_Boss_Box",
-      "display": "Crystal"
+      "display": "水晶"
     },
     {
-      "iterator": "Castle_Hp_Counter",
+      "iterator": "Castle_Hp",
+      "count": "Castle_Hp_Counter",
+      "backup": "Castle_Hp_Get",
+      "increase": true,
       "hitbox": "Castle_Hitbox",
-      "display": "Castle"
+      "display": "轮回王"
     },
     {
-      "iterator": "Dr_Hp_Counter",
+      "iterator": "Dr_Hp",
+      "count": "Dr_Hp_Counter",
+      "backup": "Dr_Hp_Get",
+      "increase": true,
       "hitbox": "Dr_Hitbox",
-      "display": "Dragon"
+      "display": "冰龙"
     },
     {
-      "iterator": "Bal_Hp_Counter",
+      "iterator": "Bal_Hp",
+      "count": "Bal_Hp_Counter",
+      "backup": "Bal_Hp_Get",
+      "increase": true,
       "hitbox": "Bal_Hitbox",
-      "display": "Balrog"
+      "display": "炎魔"
     }
   ],
   "Monsters": [


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_s_a_m
## 为什么要增加/修改这个东西
修复刀剑boss血条不显示和第五关boss打不死的问题
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
