### PR TITLE
修改地图参数: ze_slender_escape_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_slender_escape_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_slender_escape_p.cfg
@@ -36,7 +36,7 @@ mp_roundtime "20"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-mcr_map_extend_times "0"
+mcr_map_extend_times "1"
 
 // 说  明: VIP延长投票 (次)
 // 最小值: 0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_slender_escape_p
## 为什么要增加/修改这个东西
第三关与三轮小游戏关随机性过大，经常重赛导致使地图时间无法完成8关全流程，为保证能通关全流程，增加一次ext延长
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
