### PR TITLE
修改地图参数: ze_honkai_impact_3rd_babel_z

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_honkai_impact_3rd_babel_z.cfg
+++ b/2001/csgo/cfg/map-configs/ze_honkai_impact_3rd_babel_z.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "0.9"
+sv_falldamage_scale "0.0"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_honkai_impact_3rd_babel_z.cfg
+++ b/2001/csgo/cfg/map-configs/ze_honkai_impact_3rd_babel_z.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "0.0"
+sv_falldamage_scale "0.5"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_honkai_impact_3rd_babel_z
## 为什么要增加/修改这个东西
本地图相比csgo时期做了一些修改，开局第三个守点人类不得不第一时间从高空跳下去接尸笼，该高度除非是摩拉克斯，别的角色跳都会直接摔死。且该尸笼人类不得不接，僵尸漏了后有两处四楼空降点，人类撤退门在三楼，无法正面防守四楼点位，如果上四楼守，跳下三楼进门也会摔死，基本只有第一时间压尸笼的打法。现在地图有摔伤导致每次为了接尸笼时，无论指挥强调多少次不是满血摩拉克斯的别跳，依然有萌新摔死，且接尸笼成功率还偏低，多次因为这个点重赛或卖萌新。考虑到本图后面点位设计并无kz、高处空降等跳跃摔伤点位，故申请关闭本图摔伤。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
