### PR TITLE
修改地图参数: ze_chronus_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_chronus_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_chronus_p.cfg
@@ -254,7 +254,7 @@ ze_skill_yaksha_damage "2"
 // 最小值: false
 // 最大值: true
 // 类  型: bool
-ms_flashlight_enabled "false"
+ms_flashlight_enabled "true"
 
 
 Echo Executed config for ze_chronus_p.


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_chronus_p
## 为什么要增加/修改这个东西
地图中间和末尾有山洞路非常的黑，且有空降逃亡路、假摔掉水点和碎石卡脚，玩家需要手电筒辅助通关。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
