### PR TITLE
修改地图参数: ze_lotr_minas_tirith_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_lotr_minas_tirith_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_lotr_minas_tirith_p.cfg
@@ -115,7 +115,7 @@ ze_knockback_scale "1.2"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.5"
+ze_cash_damage_zombie "0.7"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_lotr_minas_tirith_p
## 为什么要增加/修改这个东西
打钱比修改原因：由于当前弹药神器有bug，刷的手雷无法正常拾取，且玩家在拾取神器以后主副武器会被清空，再者还有煤气罐僵尸，本图目前人类经常穷得连买雷点油都没人够钱买，故略微上调本图打钱比。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
