### PR TITLE
修改地图通关奖励: ze_lila_panic_escape_p

### DIFF
--- a/2001/sharp/configs/rewards/ze_lila_panic_escape_p.jsonc
+++ b/2001/sharp/configs/rewards/ze_lila_panic_escape_p.jsonc
@@ -13,67 +13,67 @@
 
 {
   "1": {
-    "rankPasses": 8,
+    "rankPasses": 6,
     "rankDamage": 20000,
     "rankIntern": 0.4,
-    "econPasses": 5,
+    "econPasses": 3,
     "econDamage": 24000,
     "econIntern": 0.2
   },
   "2": {
-    "rankPasses": 8,
+    "rankPasses": 6,
     "rankDamage": 20000,
     "rankIntern": 0.4,
-    "econPasses": 6,
+    "econPasses": 3,
     "econDamage": 24000,
     "econIntern": 0.2
   },
   "3": {
-    "rankPasses": 9,
+    "rankPasses": 6,
     "rankDamage": 20000,
     "rankIntern": 0.4,
-    "econPasses": 5,
+    "econPasses": 3,
     "econDamage": 24000,
     "econIntern": 0.2
   },
   "4": {
-    "rankPasses": 10,
+    "rankPasses": 6,
     "rankDamage": 20000,
     "rankIntern": 0.48,
-    "econPasses": 7,
+    "econPasses": 3,
     "econDamage": 24000,
     "econIntern": 0.36
   },
   "5": {
-    "rankPasses": 12,
+    "rankPasses": 7,
     "rankDamage": 20000,
     "rankIntern": 0.48,
-    "econPasses": 8,
+    "econPasses": 4,
     "econDamage": 24000,
     "econIntern": 0.36
   },
   "6": {
-    "rankPasses": 12,
+    "rankPasses": 7,
     "rankDamage": 20000,
     "rankIntern": 0.48,
-    "econPasses": 8,
+    "econPasses": 4,
     "econDamage": 24000,
     "econIntern": 0.36
   },
   "7": {
-    "rankPasses": 12,
+    "rankPasses": 8,
     "rankDamage": 20000,
-    "rankIntern": 0.6,
-    "econPasses": 8,
+    "rankIntern": 0.42,
+    "econPasses": 4,
     "econDamage": 24000,
-    "econIntern": 0.46
+    "econIntern": 0.24
   },
   "8": {
-    "rankPasses": 12,
+    "rankPasses": 8,
     "rankDamage": 20000,
-    "rankIntern": 0.6,
-    "econPasses": 8,
+    "rankIntern": 0.42,
+    "econPasses": 4,
     "econDamage": 24000,
-    "econIntern": 0.46
+    "econIntern": 0.24
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_lila_panic_escape_p
## 为什么要增加/修改这个东西
下调通关奖励,避免云点获取过多
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
