### PR TITLE
修改地图参数: ze_santassination_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_santassination_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_santassination_p.cfg
@@ -125,13 +125,13 @@ ze_cash_damage_zombie "0.6"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_hegrenade "1"
+ze_weapons_spawn_hegrenade "0"
 
 // 说  明: 每局开始时补给的火瓶数量 (个)
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_molotov "0"
+ze_weapons_spawn_molotov "1"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
@@ -143,13 +143,13 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "5"
+ze_weapons_round_hegrenade "3"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "3"
+ze_weapons_round_molotov "4"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_santassination_p
## 为什么要增加/修改这个东西
打boss雷太多导致boss被秒杀（具体如下，小santa四十五秒左右，胖santa四十秒左右，苏格拉底存的雷太多，二十秒左右），故削弱雷的最大购买数量，并把开局的雷换成火，不然还是能存雷不扔。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
