### PR TITLE
修改地图通关奖励: ze_p_v_z

### DIFF
--- a/2001/sharp/configs/rewards/ze_p_v_z.jsonc
+++ b/2001/sharp/configs/rewards/ze_p_v_z.jsonc
@@ -29,6 +29,14 @@
     "econIntern": 0.2
   },
   "3": {
+    "rankPasses": 10,
+    "rankDamage": 18000,
+    "rankIntern": 0.4,
+    "econPasses": 6,
+    "econDamage": 20000,
+    "econIntern": 0.2
+  },
+  "4": {
     "rankPasses": 9,
     "rankDamage": 20000,
     "rankIntern": 0.4,
@@ -36,28 +44,20 @@
     "econDamage": 22000,
     "econIntern": 0.2
   },
-  "4": {
-    "rankPasses": 10,
-    "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 7,
-    "econDamage": 24000,
-    "econIntern": 0.2
-  },
   "5": {
-    "rankPasses": 9,
-    "rankDamage": 18000,
-    "rankIntern": 0.48,
-    "econPasses": 6,
+    "rankPasses": 15,
+    "rankDamage": 20000,
+    "rankIntern": 0.8,
+    "econPasses": 12,
     "econDamage": 24000,
-    "econIntern": 0.22
+    "econIntern": 0.6
   },
   "6": {
-    "rankPasses": 10,
-    "rankDamage": 18000,
-    "rankIntern": 0.42,
-    "econPasses": 6,
-    "econDamage": 20000,
-    "econIntern": 0.2
+    "rankPasses": 15,
+    "rankDamage": 20000,
+    "rankIntern": 0.8,
+    "econPasses": 12,
+    "econDamage": 24000,
+    "econIntern": 0.6
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_p_v_z
## 为什么要增加/修改这个东西
由于本图神器修复及社区枪械伤害调低，本图难度已恢复如初，甚至比原本更难（因为僵尸有铁门、冰车两个神器是免疫子弹击退的，需要打碎才能阻止僵尸前进，且每一关僵尸都能拾取数个这种神器；而枪械伤害下调直接导致铁门和冰车比原本硬了非常多）。故现已联系admin立华游理恢复本图难度至原本的困难难度，且调整通关奖励至对应难度奖励，并修复了原本不尽合理的关卡难度对应的奖励分配。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
