### PR TITLE
修改地图参数: ze_backrooms_deathbed_v1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_backrooms_deathbed_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_backrooms_deathbed_v1.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "1"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "1.0"
+sv_falldamage_scale "1.2"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_backrooms_deathbed_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_backrooms_deathbed_v1.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "1"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "1.2"
+sv_falldamage_scale "1.0"
 
 
 ///
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.2"
 
 ///
 /// Economy


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_backrooms_deathbed_v1
## 为什么要增加/修改这个东西
本图难度设定为普通，地图已有小黑、笑魇、迷雾和超长逃亡路等作为地图机制构筑地图难度，当前击退偏低导致人类守点压力过大且火力容错过低，故稍微提高击退使地图重心稍微再偏向回地图机制本身，并使地图难度更符合普通难度分级。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
