### PR TITLE
修改地图参数: ze_silent_hill_3_dawn_full

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_silent_hill_3_dawn_full.cfg
+++ b/2001/csgo/cfg/map-configs/ze_silent_hill_3_dawn_full.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "0.5"
+sv_falldamage_scale "0.3"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_silent_hill_3_dawn_full
## 为什么要增加/修改这个东西
本图为寂静岭3黎明的完整版，有着相同的路线和点位。经实战测试，0.5的摔伤仍会导致非摩拉克斯职业在必经且无法避免摔落的高处摔落点位直接摔死，故确保地图能正常游玩，进一步下调本图摔伤系数。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
