### PR TITLE
修改地图通关奖励: ze_fapescape_p

### DIFF
--- a/2001/sharp/configs/rewards/ze_fapescape_p.jsonc
+++ b/2001/sharp/configs/rewards/ze_fapescape_p.jsonc
@@ -39,25 +39,25 @@
   "4": {
     "rankPasses": 12,
     "rankDamage": 20000,
-    "rankIntern": 0.68,
+    "rankIntern": 0.5,
     "econPasses": 10,
     "econDamage": 24000,
-    "econIntern": 0.56
+    "econIntern": 0.3
   },
   "5": {
     "rankPasses": 12,
     "rankDamage": 20000,
-    "rankIntern": 0.68,
+    "rankIntern": 0.5,
     "econPasses": 10,
     "econDamage": 24000,
-    "econIntern": 0.56
+    "econIntern": 0.3
   },
   "6": {
     "rankPasses": 15,
     "rankDamage": 20000,
-    "rankIntern": 0.8,
+    "rankIntern": 0.6,
     "econPasses": 12,
     "econDamage": 24000,
-    "econIntern": 0.6
+    "econIntern": 0.4
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_fapescape_p
## 为什么要增加/修改这个东西
优化本图原本失败保底奖励过高的情况。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
