### PR TITLE
修改地图参数: ze_forhidden_void

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_forhidden_void.cfg
+++ b/2001/csgo/cfg/map-configs/ze_forhidden_void.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "0"
+sv_falldamage_scale "0.1"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_forhidden_void.cfg
+++ b/2001/csgo/cfg/map-configs/ze_forhidden_void.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "1.0"
+sv_falldamage_scale "0"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_forhidden_void
## 为什么要增加/修改这个东西
该地图第三关出生点为从高处落下，其后面的传送点也有不可避免的摔伤。经测试后，摩拉克斯角色开局只有20血左右，但开局存在僵尸高伤害神器从而导致人类几乎无法正常游玩。故关闭摔伤。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
