### PR TITLE
修改地图参数: ze_tesv_skyrim_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_tesv_skyrim_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_tesv_skyrim_p.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "0.9"
+ze_knockback_scale "0.7"
 
 
 ///
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "3"
+ze_weapons_round_adrenaline "-1"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_tesv_skyrim_p
## 为什么要增加/修改这个东西
皮肤对抗图，变成了贴门咸鱼图，全关卡全是窄口，卖人卖到20:40人数都能过，故削弱击退。该图小法+奶杖，不可能没有血，如果其中一个掉了，血针也能过，故修改每局最多可购买的肾上腺素为-1
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
