### PR TITLE
修改地图参数: ze_light_shadow_cs2

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_light_shadow_cs2.cfg
+++ b/2001/csgo/cfg/map-configs/ze_light_shadow_cs2.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "1.0"
+sv_falldamage_scale "0.0"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_light_shadow_cs2
## 为什么要增加/修改这个东西
本图第三关最后是躲天坠弹幕，躲完以后脚底地板会破碎并摔落一大段距离，实测摩拉克斯会从110血摔到30血，别的角色更是会直接躲完弹幕后在核爆前摔死。考虑到本图地形设计并无摔落点位，只有一些传送点后无可避免的摔伤，且摔掉血会严重影响玩家躲二三关流程中的伤害弹幕，间接提升了不少本图难度，也降低可吃伤害弹幕数——即存活容错率，使地图难度超出原本设定值。故申请关闭本图摔伤。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
