### PR TITLE
修改地图参数: ze_p_v_z

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_p_v_z.cfg
+++ b/2001/csgo/cfg/map-configs/ze_p_v_z.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "1.0"
+sv_falldamage_scale "0.5"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_p_v_z
## 为什么要增加/修改这个东西
本图第六关为boss关，没有设计尸笼，偶尔几只僵尸登场只有3000血且不回血，boss也是出技能多，hitbox只有在固定阶段才出现一小会儿给人类打掉boss血量，总而言之即人类没有有效的打钱手段，基本只能靠每10s系统发放的金钱。而第六关进boss房传送点还是在半空中，实测开局抢完神器再黑屏进boss房摔落后非摩拉克斯只剩27血，boss技能伤害大致有40、60和秒杀三档，且本图并无一次性让人类回满血的神器，开局金钱也并不能立刻买血针，导致很多萌新第一个技能就死了；哪怕买了血针打了一次，由于没钱了后面人类躲技能容错也会变得很低。再结合到地图作者表示本图设计是不开摔伤的，但考虑本图有摔伤是能通关的，故仅申请下调本图摔伤。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
