### PR TITLE
修改地图参数: ze_pirates_port_royal

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_pirates_port_royal.cfg
+++ b/2001/csgo/cfg/map-configs/ze_pirates_port_royal.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "1.0"
+sv_falldamage_scale "0.5"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_pirates_port_royal
## 为什么要增加/修改这个东西
大章鱼第五关跳进矿洞的点位，在满血145血的情况下动力小子直接摔死，其余职业除摩拉克斯外都会摔残，正常游玩的话僵尸有反伤和刀锋且有僵尸神器巴博萨，萌新玩家在这个点摔死的很多，所以调整摔伤，增加存活率。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
