### PR TITLE
修改地图通关奖励: ze_steyliff_grove

### DIFF
--- a/2001/sharp/configs/rewards/ze_steyliff_grove.jsonc
+++ b/2001/sharp/configs/rewards/ze_steyliff_grove.jsonc
@@ -17,7 +17,7 @@
     "rankDamage": 26000,
     "rankIntern": 0.4,
     "econPasses": 15,
-    "econDamage": 28000,
+    "econDamage": 30000,
     "econIntern": 0.25
   }
 }

--- a/2001/sharp/configs/rewards/ze_steyliff_grove.jsonc
+++ b/2001/sharp/configs/rewards/ze_steyliff_grove.jsonc
@@ -13,19 +13,11 @@
 
 {
   "1": {
-    "rankPasses": 16,
-    "rankDamage": 22000,
+    "rankPasses": 20,
+    "rankDamage": 26000,
     "rankIntern": 0.4,
-    "econPasses": 10,
-    "econDamage": 24000,
-    "econIntern": 0.25
-  },
-  "2": {
-    "rankPasses": 14,
-    "rankDamage": 22000,
-    "rankIntern": 0.4,
-    "econPasses": 8,
-    "econDamage": 25000,
+    "econPasses": 15,
+    "econDamage": 28000,
     "econIntern": 0.25
   }
 }

--- a/2001/sharp/configs/rewards/ze_steyliff_grove.jsonc
+++ b/2001/sharp/configs/rewards/ze_steyliff_grove.jsonc
@@ -16,7 +16,7 @@
     "rankPasses": 20,
     "rankDamage": 26000,
     "rankIntern": 0.4,
-    "econPasses": 15,
+    "econPasses": 12,
     "econDamage": 28000,
     "econIntern": 0.25
   }

--- a/2001/sharp/configs/rewards/ze_steyliff_grove.jsonc
+++ b/2001/sharp/configs/rewards/ze_steyliff_grove.jsonc
@@ -16,7 +16,7 @@
     "rankPasses": 20,
     "rankDamage": 26000,
     "rankIntern": 0.4,
-    "econPasses": 12,
+    "econPasses": 15,
     "econDamage": 28000,
     "econIntern": 0.25
   }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_steyliff_grove
## 为什么要增加/修改这个东西
地图实际只有一关的长征图，大场景有boss战和跳刀，故调整地图对应通关奖励以符合实际难度
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
