### PR TITLE
修改地图参数: ze_easy_escape_v4

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_easy_escape_v4.cfg
+++ b/2001/csgo/cfg/map-configs/ze_easy_escape_v4.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "1"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "0.5"
+sv_falldamage_scale "0.0"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_easy_escape_v4
## 为什么要增加/修改这个东西
本图最后有三段高难度滑翔触发路，最后一段要从高处下落进入传送板，传送后落地会造成高额摔伤，如果触发手摔死则无法成功触发，不触发僵尸和人类就会同传直接团灭。当前地图只能通过非常厉害的滑翔高手，在最后一段坡提前出坡降低高度以保证不摔死，再成功触发，本身难度就不低，现在对技术要求更高，容错率也更低。考虑到滑翔图动不动就是上千的速度，如果地图没有设计落地水，本身就不应有摔伤，高空速落地会对摔伤有极大加成，故申请关闭本图摔伤。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
