### PR TITLE
修改地图参数: ze_abandoned_industry_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_abandoned_industry_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_abandoned_industry_p.cfg
@@ -239,7 +239,7 @@ ze_skill_cirrus_range "96"
 // 最小值: false
 // 最大值: true
 // 类  型: bool
-ms_flashlight_enabled "false"
+ms_flashlight_enabled "true"
 
 
 Echo Executed config for ze_abandoned_industry_p.


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_abandoned_industry_p
## 为什么要增加/修改这个东西
地图黑暗点较多，添加地图手电筒以便萌新玩家游玩
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
