### PR TITLE
修改地图参数: ze_tyranny2

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_tyranny2.cfg
+++ b/2001/csgo/cfg/map-configs/ze_tyranny2.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.4"
+ze_knockback_scale "1.3"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.4"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.9"
+ze_cash_damage_zombie "1.0"
 
 
 ///
@@ -156,7 +156,7 @@ ze_weapons_round_molotov "3"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_decoy "-1"
+ze_weapons_round_decoy "1"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -168,7 +168,7 @@ ze_weapons_round_flash "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_tyranny2
## 为什么要增加/修改这个东西
目前该地图胜率较低，且地图版本基于css魔改，相对于csgo版本整体难度上升，且僵尸在前4关拥有虚空（远程黑洞）神器和改版的秒杀神器，人类守点难度对比精灵塔地图更高，故开放黑洞雷和冰冻雷购买；地图刷分点较少且人类路程需要大量道具拖延僵尸进攻，且存在需要爬梯子的高低差地形，故在不调整地图摔伤的情况下，调整地图打钱比。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
