### PR TITLE
修改地图翻译: ze_ffvii_mako_reactor_v5_3

### DIFF
--- a/2001/sharp/configs/translations/ze_ffvii_mako_reactor_v5_3.jsonc
+++ b/2001/sharp/configs/translations/ze_ffvii_mako_reactor_v5_3.jsonc
@@ -119,10 +119,10 @@
     "blocked": true
   },
   "** EXPLOSION IN 120 SECONDS **": {
-    "translation": "** 距离魔光炉爆炸还剩一百二十秒! **"
+    "translation": "** 距离魔光炉爆炸还剩120秒! **"
   },
   "** EXPLOSION IN 130 SECONDS **": {
-    "translation": "** 距离魔光炉爆炸还剩一百三十秒! **"
+    "translation": "** 距离魔光炉爆炸还剩130秒! **"
   },
   "** 30 SECONDS LEFT **": {
     "translation": "** 还剩30秒 **"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffvii_mako_reactor_v5_3
## 为什么要增加/修改这个东西
修复bug翻译
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
