### PR TITLE
修改地图通关奖励: ze_surf_okitsu_shonyudo

### DIFF
--- a/2001/sharp/configs/rewards/ze_surf_okitsu_shonyudo.jsonc
+++ b/2001/sharp/configs/rewards/ze_surf_okitsu_shonyudo.jsonc
@@ -13,19 +13,19 @@
 
 {
   "1": {
-    "rankPasses": 7,
+    "rankPasses": 10,
     "rankDamage": 18000,
     "rankIntern": 0.4,
-    "econPasses": 4,
+    "econPasses": 8,
     "econDamage": 24000,
-    "econIntern": 0.2
+    "econIntern": 0.25
   },
   "2": {
-    "rankPasses": 7,
+    "rankPasses": 12,
     "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 5,
+    "rankIntern": 0.45,
+    "econPasses": 9,
     "econDamage": 24000,
-    "econIntern": 0.2
+    "econIntern": 0.3
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_surf_okitsu_shonyudo
## 为什么要增加/修改这个东西
本图是两关的滑翔火力小长征困难图，每一关的流程大约有15~20分钟。本图对火力和断后要求极高，场地宽广且地形复杂，人类只能边断边退拖时间到门开，且路上有很多跳口和卡脚点；滑翔部分难度明显高于咸鱼滑翔图，且无任何逃课打法，必须全员滑翔，对玩家综合能力和现场发挥水平要求较高。考虑到本图是困难难度的地图，且当前通关奖励明显过低，故申请将本图通关奖励调整至本地图难度对应的档位。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
