### PR TITLE
修改地图参数: ze_box_defend_v1_4

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_box_defend_v1_4.cfg
+++ b/2001/csgo/cfg/map-configs/ze_box_defend_v1_4.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.3"
 
 
 ///
@@ -144,13 +144,13 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "4"
+ze_weapons_round_hegrenade "6"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "2"
+ze_weapons_round_molotov "3"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_box_defend_v1_4
## 为什么要增加/修改这个东西
本图由于地形设计，原本就是守点压力非常大的地图，如今尸变比调整到1:4以后，只要僵尸玩家不挂机，有几个关卡难以通过，导致本图难度远超其原本入门的难度设定，故申请上调本图击退和增加少量道具数。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
