### PR TITLE
修改地图参数: ze_forius_just_run_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_forius_just_run_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_forius_just_run_p.cfg
@@ -239,7 +239,7 @@ ze_skill_cirrus_range "128"
 // 最小值: false
 // 最大值: true
 // 类  型: bool
-ms_flashlight_enabled "false"
+ms_flashlight_enabled "true"
 
 
 Echo Executed config for ze_forius_just_run_p.


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_forius_just_run_p
## 为什么要增加/修改这个东西
本图前期有一个隐藏跳口陷阱，开手电筒可以辅助更好看清陷阱边缘以便跳过去，且落入陷阱下方以后非常黑，重新跳上地面的路是黑暗中的一个小kz箱子，萌新需要手电筒辅助照明以便更好的照路返回地面，故申请开放本图手电筒使用。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
