### PR TITLE
修改地图参数: mg_thc_lego_multimap

### DIFF
--- a/2004/sharp/configs/maps.json
+++ b/2004/sharp/configs/maps.json
@@ -203,7 +203,7 @@
     "price": 300
   },
   "mg_thc_lego_multimap": {
-    "admin": false,
+    "admin": true,
     "certainTimes": [-1],
     "cooldown": 15,
     "nomination": false,


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
mg_thc_lego_multimap
## 为什么要增加/修改这个东西
本图混战选关容易出现卡人导致无人选图问题，故修改此配置
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
