### PR TITLE
修改地图通关奖励: ze_diverted_destiny

### DIFF
--- a/2001/sharp/configs/rewards/ze_diverted_destiny.jsonc
+++ b/2001/sharp/configs/rewards/ze_diverted_destiny.jsonc
@@ -35,5 +35,13 @@
     "econPasses": 8,
     "econDamage": 22000,
     "econIntern": 0.21
+  },
+  "4": {
+    "rankPasses": 15,
+    "rankDamage": 18000,
+    "rankIntern": 0.52,
+    "econPasses": 8,
+    "econDamage": 22000,
+    "econIntern": 0.31
   }
 }

--- a/2001/sharp/configs/rewards/ze_diverted_destiny.jsonc
+++ b/2001/sharp/configs/rewards/ze_diverted_destiny.jsonc
@@ -14,7 +14,7 @@
 {
   "1": {
     "rankPasses": 10,
-    "rankDamage": 18000,
+    "rankDamage": 20000,
     "rankIntern": 0.42,
     "econPasses": 7,
     "econDamage": 22000,
@@ -22,7 +22,7 @@
   },
   "2": {
     "rankPasses": 10,
-    "rankDamage": 18000,
+    "rankDamage": 20000,
     "rankIntern": 0.42,
     "econPasses": 7,
     "econDamage": 22000,
@@ -30,7 +30,7 @@
   },
   "3": {
     "rankPasses": 12,
-    "rankDamage": 18000,
+    "rankDamage": 20000,
     "rankIntern": 0.42,
     "econPasses": 8,
     "econDamage": 22000,
@@ -38,10 +38,10 @@
   },
   "4": {
     "rankPasses": 15,
-    "rankDamage": 18000,
+    "rankDamage": 22000,
     "rankIntern": 0.52,
     "econPasses": 8,
-    "econDamage": 22000,
+    "econDamage": 24000,
     "econIntern": 0.31
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_diverted_destiny
## 为什么要增加/修改这个东西
该地图于1月31日增加ex关卡，并且已经更新，补充第四关奖励，且该地图包含很多刷分点，降低伤害结算云点比例
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
