### PR TITLE
修改地图通关奖励: ze_skyline

### DIFF
--- a/2001/sharp/configs/rewards/ze_skyline.jsonc
+++ b/2001/sharp/configs/rewards/ze_skyline.jsonc
@@ -13,10 +13,10 @@
 
 {
   "1": {
-    "rankPasses": 5,
+    "rankPasses": 6,
     "rankDamage": 18000,
     "rankIntern": 0.4,
-    "econPasses": 3,
+    "econPasses": 4,
     "econDamage": 20000,
     "econIntern": 0.2
   }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_skyline
## 为什么要增加/修改这个东西
本图是全程逃亡路设计的地图，且地形复杂光线较暗，侧路及kz捷径路繁多；再者考虑移植到cs2后删除了很多空气墙，再加上社区的僵尸技能能更快越过一些捷径加快追尾，整体通关难度在咸鱼图中偏高，故申请上调本图通关奖励。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
