### PR TITLE
修改地图通关奖励: ze_blood_castle

### DIFF
--- a/2001/sharp/configs/rewards/ze_blood_castle.jsonc
+++ b/2001/sharp/configs/rewards/ze_blood_castle.jsonc
@@ -14,10 +14,10 @@
 {
   "1": {
     "rankPasses": 6,
-    "rankDamage": 18000,
+    "rankDamage": 35000,
     "rankIntern": 0.4,
     "econPasses": 4,
-    "econDamage": 20000,
+    "econDamage": 40000,
     "econIntern": 0.2
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_blood_castle
## 为什么要增加/修改这个东西
本图由于地图移植问题，撤退路上原本一个无法防守的点变为了人类刷分点，人类可以刷2分钟后再一次性跑完后面的逃亡路，导致本图人类通关可刷到的伤害远超预期，故申请上调本关伤害奖励阈值。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
