### PR TITLE
修改地图参数: ze_obj_muiltmaps

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obf_filth_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_filth_v1.cfg
@@ -173,7 +173,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "4"
+ze_weapons_round_adrenaline "8"
 
 
 ///
@@ -226,7 +226,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "128"
+ze_skill_cirrus_range "96"
 
 
 

--- a/2001/csgo/cfg/map-configs/ze_obf_insane.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_insane.cfg
@@ -173,7 +173,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "6"
+ze_weapons_round_adrenaline "8"
 
 
 ///
@@ -226,7 +226,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "128"
+ze_skill_cirrus_range "96"
 
 
 

--- a/2001/csgo/cfg/map-configs/ze_obf_npst_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_npst_v1.cfg
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "7"
+ze_weapons_round_adrenaline "10"
 
 
 ///
@@ -227,7 +227,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "128"
+ze_skill_cirrus_range "96"
 
 
 

--- a/2001/csgo/cfg/map-configs/ze_obf_npst_v2.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_npst_v2.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "0.7"
+sv_falldamage_scale "0.0"
 
 
 ///
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.1"
 
 
 ///
@@ -150,13 +150,13 @@ ze_weapons_round_hegrenade "15"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "7"
+ze_weapons_round_molotov "8"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_decoy "6"
+ze_weapons_round_decoy "7"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "5"
+ze_weapons_round_adrenaline "8"
 
 
 ///
@@ -227,7 +227,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "128"
+ze_skill_cirrus_range "96"
 
 
 

--- a/2001/csgo/cfg/map-configs/ze_obf_rampage_v2_legacy.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_rampage_v2_legacy.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.1"
 
 
 ///
@@ -144,7 +144,7 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "13"
+ze_weapons_round_hegrenade "16"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -156,7 +156,7 @@ ze_weapons_round_molotov "8"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_decoy "6"
+ze_weapons_round_decoy "7"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -227,7 +227,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "128"
+ze_skill_cirrus_range "96"
 
 
 

--- a/2001/csgo/cfg/map-configs/ze_obf_rescape.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_rescape.cfg
@@ -173,7 +173,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "6"
+ze_weapons_round_adrenaline "10"
 
 
 ///
@@ -226,7 +226,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "128"
+ze_skill_cirrus_range "96"
 
 
 

--- a/2001/csgo/cfg/map-configs/ze_obj_ember.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_ember.cfg
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "7"
+ze_weapons_round_adrenaline "10"
 
 
 ///
@@ -227,7 +227,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "128"
+ze_skill_cirrus_range "96"
 
 
 

--- a/2001/csgo/cfg/map-configs/ze_obj_encounter.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_encounter.cfg
@@ -173,7 +173,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "6"
+ze_weapons_round_adrenaline "10"
 
 
 ///
@@ -226,7 +226,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "128"
+ze_skill_cirrus_range "96"
 
 
 

--- a/2001/csgo/cfg/map-configs/ze_obj_escalation_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_escalation_v1.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.3"
 
 ///
 /// Economy
@@ -173,7 +173,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "6"
+ze_weapons_round_adrenaline "10"
 
 
 ///
@@ -226,7 +226,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "128"
+ze_skill_cirrus_range "96"
 
 
 

--- a/2001/csgo/cfg/map-configs/ze_obj_goosestep_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_goosestep_v1.cfg
@@ -173,7 +173,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "6"
+ze_weapons_round_adrenaline "10"
 
 
 ///
@@ -226,7 +226,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "128"
+ze_skill_cirrus_range "96"
 
 
 

--- a/2001/csgo/cfg/map-configs/ze_obj_ouroboros_aurora.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_ouroboros_aurora.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.3"
 
 ///
 /// Economy
@@ -114,7 +114,7 @@ ze_knockback_scale "1.2"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.9"
+ze_cash_damage_zombie "1.0"
 
 
 ///
@@ -173,7 +173,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "6"
+ze_weapons_round_adrenaline "8"
 
 
 ///
@@ -226,7 +226,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "128"
+ze_skill_cirrus_range "96"
 
 
 

--- a/2001/csgo/cfg/map-configs/ze_obj_ouroboros_ragnarok.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_ouroboros_ragnarok.cfg
@@ -173,7 +173,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "6"
+ze_weapons_round_adrenaline "10"
 
 
 ///
@@ -226,7 +226,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "128"
+ze_skill_cirrus_range "96"
 
 
 

--- a/2001/csgo/cfg/map-configs/ze_obj_rampage_v1_2.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_rampage_v1_2.cfg
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "5"
+ze_weapons_round_adrenaline "8"
 
 
 ///
@@ -227,7 +227,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "128"
+ze_skill_cirrus_range "96"
 
 
 

--- a/2001/csgo/cfg/map-configs/ze_obj_redemption.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_redemption.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.1"
+ze_knockback_scale "1.2"
 
 
 ///
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "7"
+ze_weapons_round_adrenaline "10"
 
 
 ///
@@ -227,7 +227,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "128"
+ze_skill_cirrus_range "96"
 
 
 

--- a/2001/csgo/cfg/map-configs/ze_obj_void_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_void_v1.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.1"
 
 
 ///
@@ -144,19 +144,19 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "12"
+ze_weapons_round_hegrenade "14"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "7"
+ze_weapons_round_molotov "8"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_decoy "5"
+ze_weapons_round_decoy "7"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "6"
+ze_weapons_round_adrenaline "10"
 
 
 ///
@@ -227,7 +227,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "128"
+ze_skill_cirrus_range "96"
 
 
 


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_muiltmaps
## 为什么要增加/修改这个东西
1.近期因长手数值增强导致大部分obj类地图对抗程度急剧上升，且可利用地图各种高低差等地形优势，可轻易击杀人类，故平衡所有obj地图的长手数值恢复至96；
2.玩家反馈目前参数过于困难，且根据近期通关率较低情况和完美平台萌新玩家占比日益上升，上调部分地图的人类各项数值（击退、道具数量和打钱比）；
3.npstV2 boss战前因存在2处高低差，第一个高低差（栏杆处落大坝顶处）导致的摔伤会进一步缩小奶神器容错，第二个高低差（大坝落水处）因地图水实体并无大范围防摔伤将导致人类方玩家有摔死的情况（除非精确落在正中间瀑布底处），故申请关闭该地图摔伤。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
