### PR TITLE
修改地图参数: ze_hydroponic_garden

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_hydroponic_garden.cfg
+++ b/2001/csgo/cfg/map-configs/ze_hydroponic_garden.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.3"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.2"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.8"
+ze_cash_damage_zombie "0.9"
 
 
 ///
@@ -144,7 +144,7 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "6"
+ze_weapons_round_hegrenade "8"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -156,7 +156,7 @@ ze_weapons_round_molotov "4"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_decoy "2"
+ze_weapons_round_decoy "3"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "3"
+ze_weapons_round_adrenaline "2"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_hydroponic_garden
## 为什么要增加/修改这个东西
本图是有M4dara制作的多关超空旷场地弹幕图，且关卡路上有多处高强度守点、kz触发、kz逃亡路和神器对抗，由于近两个月多次的社区参数调整，本地图的通关难度远失平衡，原本适中的通关难度现在已经变成人类牢十多二十把都过不了的地图，且近半个月以来打的战绩都非常差。再考虑到弹幕地图最后一两关的结尾往往附带长kz逃亡路或弹幕，关卡前中段的守点不应难度过高，再加上地图设计路极宽大，人类并不能非常有效地集中火力和高效多次命中僵尸。故申请整体提高本图参数，尝试将通关难度调整到合理难度；同时优化本图血针数量，减少原本过量提供的血针。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
