### PR TITLE
修改地图参数: ze_sisyphus

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_sisyphus.cfg
+++ b/2001/csgo/cfg/map-configs/ze_sisyphus.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "1.0"
+sv_falldamage_scale "0.0"
 
 
 ///
@@ -70,7 +70,7 @@ ze_infect_sort_by_immunity "true"
 // 最小值: 1
 // 最大值: 64
 // 类  型: int32
-ze_infect_mother_ratio "7"
+ze_infect_mother_ratio "16"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: false
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.3"
+ze_knockback_scale "2.2"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.3"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.8"
+ze_cash_damage_zombie "3.0"
 
 
 ///
@@ -132,7 +132,7 @@ ze_weapons_spawn_hegrenade "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_molotov "0"
+ze_weapons_spawn_molotov "1"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
@@ -150,31 +150,31 @@ ze_weapons_round_hegrenade "5"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "4"
+ze_weapons_round_molotov "10"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_decoy "3"
+ze_weapons_round_decoy "10"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "5"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_smoke "1"
+ze_weapons_round_smoke "2"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "2"
+ze_weapons_round_adrenaline "4"
 
 
 ///
@@ -197,7 +197,7 @@ ze_skill_faster_speed "1.4"
 // 最小值: 40.0
 // 最大值: 1000.0
 // 类  型: float
-ze_skill_blader_damage "64.0"
+ze_skill_blader_damage "40.0"
 
 // 说  明: 恶魔技能连锁次数 (次)
 // 最小值: 3


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_sisyphus
## 为什么要增加/修改这个东西
地图存在高处摔落导致的不可避免的摔伤，故关闭摔伤。
增加击退、打钱和开局尸变比例，上调道具上限数量降低防守僵尸难度。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
