### PR TITLE
修改地图参数: ze_20_seconds_v1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_20_seconds_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_20_seconds_v1.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.4"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.2"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.9"
+ze_cash_damage_zombie "1.0"
 
 
 ///
@@ -126,37 +126,37 @@ ze_cash_damage_zombie "0.9"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_hegrenade "1"
+ze_weapons_spawn_hegrenade "2"
 
 // 说  明: 每局开始时补给的火瓶数量 (个)
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_molotov "0"
+ze_weapons_spawn_molotov "1"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_decoy "1"
+ze_weapons_spawn_decoy "0"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "6"
+ze_weapons_round_hegrenade "12"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "3"
+ze_weapons_round_molotov "5"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_decoy "2"
+ze_weapons_round_decoy "0"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_20_seconds_v1
## 为什么要增加/修改这个东西
本图设定为简单图，但由于地形和关卡设计，当前对人类通关要求难度过高，且vip玩家过少时，没有足够的屏障和黑洞，本图目前没有特别有效的通关方法；再者，本图最后的点位设计比较卖人，经常前面保了接近50人，到最后一个点被卖得剩下十几个甚至有过solo，本质原因是最后一个点是二段空降+僵尸贴脸传送设计，人类无法通过开枪有效防守，资金也因为刀锋煤气罐和前面大量的90度角落开黑守点的大量消耗，相对比较难在后期再给出足够的道具。综上所述，申请较大幅度释放本图参数，降低通关难度，提高人类通关容错率。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
