### PR TITLE
修改地图翻译: ze_no_title_cs2_l

### DIFF
--- a/2001/sharp/configs/translations/ze_no_title_cs2_l.jsonc
+++ b/2001/sharp/configs/translations/ze_no_title_cs2_l.jsonc
@@ -123,7 +123,7 @@
     "blocked": true
   },
   "***Upper Laser***": {
-    "translation": "***上面的激光!***"
+    "translation": "***前面的激光!***"
   },
   "***Crouch***": {
     "translation": "***蹲下!***"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_no_title_cs2_l
## 为什么要增加/修改这个东西
地图翻译描述有误，导致玩家容易误判，故申请修复本图翻译不准确问题。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
