### PR TITLE
修改地图参数: ze_p_v_z

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_p_v_z.cfg
+++ b/2001/csgo/cfg/map-configs/ze_p_v_z.cfg
@@ -144,7 +144,7 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "5"
+ze_weapons_round_hegrenade "7"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -162,13 +162,13 @@ ze_weapons_round_decoy "2"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_flash "1"
+ze_weapons_round_flash "2"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_smoke "1"
+ze_weapons_round_smoke "-1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_p_v_z
## 为什么要增加/修改这个东西
该地图依旧存在传送点丢黑洞使大量僵尸聚集,随后使用秒杀神器:大嘴花操作僵尸
故移除黑洞道具以避免过度依赖黑洞,导致双方神器对抗性降低
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
