### PR TITLE
修改地图参数: ze_aot_trost_v6r

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_aot_trost_v6r.cfg
+++ b/2001/csgo/cfg/map-configs/ze_aot_trost_v6r.cfg
@@ -64,7 +64,7 @@ sv_falldamage_scale "1.0"
 // 最小值: false
 // 最大值: true
 // 类  型: bool
-ze_infect_sort_by_immunity "true"
+ze_infect_sort_by_immunity "false"
 
 // 说  明: 尸变比 (人)
 // 最小值: 1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_aot_trost_v6r
## 为什么要增加/修改这个东西
此地图为神器对抗图 僵尸皮肤类型的神器数量较多,
为避免回合结算前退出服务器卡尸变指数故更改成随机尸变
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
