### PR TITLE
修改地图参数: ze_frozen_abyss

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_frozen_abyss.cfg
+++ b/2001/csgo/cfg/map-configs/ze_frozen_abyss.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "0.4"
+sv_falldamage_scale "0"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_frozen_abyss
## 为什么要增加/修改这个东西
地图游玩时存在多处不可避免高摔伤落点，当前摔伤参数依然会摔死，结合地图大场景守点且地图难度，申请关闭摔伤
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
