### PR TITLE
修改地图参数: ze_barrage_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_barrage_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_barrage_p.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "0.8"
+ze_knockback_scale "1.1"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "0.8"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.8"
+ze_cash_damage_zombie "0.9"
 
 
 ///
@@ -144,13 +144,13 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "4"
+ze_weapons_round_hegrenade "6"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "2"
+ze_weapons_round_molotov "4"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_barrage_p
## 为什么要增加/修改这个东西
本地图为一张全程只有4个长守点的咸鱼图，地图场景非常黑，且每个守点僵尸有多个进攻路线，且僵尸进攻点位离人类防守点非常近，部分点位胜似小obj。当前参数对人类通关火力要求过于苛刻，在全图乌漆嘛黑的情况下萌新连在黑暗的森林中找清楚路都十分费力，守点火力要求应当下降，将难度重心转为让萌新在黑暗中寻对路线且不被追尾，故申请上调本图几项参数。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
