### PR TITLE
修改地图翻译: ze_bluearchive_abydos_b1

### DIFF
--- a/2001/sharp/configs/translations/ze_bluearchive_abydos_b1.jsonc
+++ b/2001/sharp/configs/translations/ze_bluearchive_abydos_b1.jsonc
@@ -13,11 +13,21 @@
   "<<30s>>": {
     "translation": "<<30s>>"
   },
+  "<<40s>>": {
+    "translation": "<<电闸将在40s后关闭>>"
+  },
+  "<<35s>>": {
+    "translation": "<<35s>>"
+  },
+  "<<25s>>": {
+    "translation": "<<25s>>"
+  },
   "<<10s>>": {
     "translation": "<<10s>>"
   },
   "<<5s>>": {
-    "translation": "<<5s>>"
+    "translation": "<<5s>>",
+    "blocked": true
   },
   "阿罗娜<<钢盔团和PMC集团合作占领了阿拜多斯学校>>": {
     "translation": "阿罗娜<<钢盔团和PMC集团合作占领了阿拜多斯学校>>"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_bluearchive_abydos_b1
## 为什么要增加/修改这个东西
1.补充第二关部分门倒计时，屏蔽星野跳跃技能cd的地图文本提示；
2.关于20行和23行的倒计时不做出屏蔽的解释：已进行单机跑图测试，并非是同一个门，地图存在40s 35s 25s的门。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
