### PR TITLE
修改地图参数: ze_dark_souls

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_dark_souls.cfg
+++ b/2001/csgo/cfg/map-configs/ze_dark_souls.cfg
@@ -93,7 +93,7 @@ ze_infect_mother_spawn_time "15"
 // 最小值: 0
 // 最大值: 1000
 // 类  型: int32
-ze_spawn_start_health_override "200"
+ze_spawn_start_health_override "0"
 
 
 ///
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "200"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "2.0"
+ze_knockback_scale "1.8"
 
 ///
 /// Economy
@@ -137,43 +137,43 @@ ze_weapons_spawn_molotov "0"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_decoy "1"
+ze_weapons_spawn_decoy "0"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "15"
+ze_weapons_round_hegrenade "20"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "8"
+ze_weapons_round_molotov "10"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_decoy "5"
+ze_weapons_round_decoy "-1"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_flash "1"
+ze_weapons_round_flash "-1"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_smoke "1"
+ze_weapons_round_smoke "-1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "6"
+ze_weapons_round_adrenaline "-1"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_dark_souls
## 为什么要增加/修改这个东西
作者认为所有带控制的道具不能出现在他的地图中，并且不能出现血针，新版难度降低，并且作者后续办首通地图活动，为保持活动公平性，故修改初始血量为关闭，全局击退降低为原先的参数，冰屏障黑洞为-1，增加其他道具数量，血针为-1
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
