### PR TITLE
修改地图参数: ze_obf_rampage_v24

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obf_rampage_v24.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_rampage_v24.cfg
@@ -162,13 +162,13 @@ ze_weapons_round_decoy "7"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "1"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_smoke "1"
+ze_weapons_round_smoke "-1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_obf_rampage_v24.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_rampage_v24.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "0.9"
+ze_knockback_scale "1.0"
 
 
 ///
@@ -144,19 +144,19 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "16"
+ze_weapons_round_hegrenade "13"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "8"
+ze_weapons_round_molotov "7"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_decoy "7"
+ze_weapons_round_decoy "6"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_obf_rampage_v24.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_rampage_v24.cfg
@@ -132,13 +132,13 @@ ze_weapons_spawn_hegrenade "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_molotov "1"
+ze_weapons_spawn_molotov "0"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_decoy "1"
+ze_weapons_spawn_decoy "0"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_obf_rampage_v24.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_rampage_v24.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.1"
+ze_knockback_scale "0.9"
 
 
 ///
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "5"
+ze_weapons_round_adrenaline "8"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_obf_rampage_v24.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_rampage_v24.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "0.7"
+sv_falldamage_scale "0.5"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obf_rampage_v24
## 为什么要增加/修改这个东西
1.近期此图通关率较高，且目前神器平衡问题已得到修正，为平衡双方游戏体验，减少人类道具可购买数量，因存在神器守点难度大大降低，故稍微调整击退值以确保双方平衡。
3.因地图存在多个导致玩家减少大量血量的高低差（下山，下炉子，终点房前的大坝高低差），0.7摔伤比可导致玩家血线过低甚至死亡，且存在多个刀锋必定操作的角落点，故再次降低摔伤为0.5比例
4.此地图与#2256地图地形一致，故参数平衡与#2256相似。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
