### PR TITLE
修改地图参数: ze_obf_rampage_v24

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obf_rampage_v24.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_rampage_v24.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.1"
+ze_knockback_scale "0.9"
 
 
 ///
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "5"
+ze_weapons_round_adrenaline "8"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)

## 为什么要增加/修改这个东西
1.近期此图通关率较高，且根据最近调整的枪械定身强度，为平衡双方游戏体验，降低击退至与咸鱼图击退对等。
2.地图奶神器和血针数量不足以确保人类方正常存活，故添加血针数量
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
