### PR TITLE
修改地图通关奖励: ze_shroomforest3_p

### DIFF
--- a/2001/sharp/configs/rewards/ze_shroomforest3_p.jsonc
+++ b/2001/sharp/configs/rewards/ze_shroomforest3_p.jsonc
@@ -13,10 +13,10 @@
 
 {
   "1": {
-    "rankPasses": 7,
+    "rankPasses": 10,
     "rankDamage": 18000,
     "rankIntern": 0.4,
-    "econPasses": 4,
+    "econPasses": 8,
     "econDamage": 24000,
     "econIntern": 0.2
   },
@@ -24,47 +24,47 @@
     "rankPasses": 7,
     "rankDamage": 18000,
     "rankIntern": 0.4,
-    "econPasses": 4,
+    "econPasses": 5,
     "econDamage": 24000,
     "econIntern": 0.2
   },
   "3": {
-    "rankPasses": 7,
+    "rankPasses": 10,
     "rankDamage": 18000,
     "rankIntern": 0.4,
-    "econPasses": 4,
+    "econPasses": 6,
     "econDamage": 24000,
     "econIntern": 0.25
   },
   "4": {
-    "rankPasses": 9,
+    "rankPasses": 10,
     "rankDamage": 18000,
     "rankIntern": 0.4,
-    "econPasses": 5,
+    "econPasses": 6,
     "econDamage": 24000,
     "econIntern": 0.24
   },
   "5": {
-    "rankPasses": 9,
-    "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 5,
-    "econDamage": 24000,
-    "econIntern": 0.3
-  },
-  "6": {
-    "rankPasses": 10,
+    "rankPasses": 8,
     "rankDamage": 18000,
     "rankIntern": 0.4,
     "econPasses": 6,
     "econDamage": 24000,
     "econIntern": 0.3
   },
-  "7": {
-    "rankPasses": 14,
+  "6": {
+    "rankPasses": 12,
     "rankDamage": 18000,
     "rankIntern": 0.4,
-    "econPasses": 8,
+    "econPasses": 10,
+    "econDamage": 24000,
+    "econIntern": 0.3
+  },
+  "7": {
+    "rankPasses": 15,
+    "rankDamage": 18000,
+    "rankIntern": 0.4,
+    "econPasses": 12,
     "econDamage": 24000,
     "econIntern": 0.3
   }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_shroomforest3_p
## 为什么要增加/修改这个东西
1.该地图与其它两张蘑菇相比，因通关难度直线上升，而奖励相比蘑菇1 2基本一致，故上调该地图通关奖励符合地图难度；
2.因地图第1、3、4、6关（非跳刀关卡）boss房难度较高，第1、4关boss伤害较高导致减员，第4、6关boss血量过厚且同时需防守僵尸，若萌新较多很难一把通关，故给予特定关卡更高的奖励
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
