### PR TITLE
修改地图数据: ze_otakuroom_pt

### DIFF
--- a/2001/sharp/configs/maps.json
+++ b/2001/sharp/configs/maps.json
@@ -2490,7 +2490,7 @@
     "nomination": true,
     "price": 300,
     "requiredOnline": -1,
-    "requiredPlayers": -1
+    "requiredPlayers": 30
   },
   "ze_outlast": {
     "admin": false,


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_otakuroom_pt
## 为什么要增加/修改这个东西
本图用跑图模式平局以后依然会进入下一关，导致玩家用本图暖服时到最后会进入zm关循环，故申请修改本图可预订人数，不让玩家用本图暖服。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
