### PR TITLE
修改地图翻译: ze_forsaken_temple

### DIFF
--- a/2001/sharp/configs/translations/ze_forsaken_temple.jsonc
+++ b/2001/sharp/configs/translations/ze_forsaken_temple.jsonc
@@ -132,7 +132,6 @@
   },
   "** Pit is opening in 20s **": {
     "translation": "** 20秒后打开井口 **",
-    "blocked": true
   },
   "** Nicely done! You got the correct combination! **": {
     "translation": "** 做得好,钥匙被放在了正确的位置上! **"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_forsaken_temple
## 为什么要增加/修改这个东西
原本翻译block设置错误导致地图关键倒计时无法正常显示，故申请去除原本错误的block设置。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
