### PR TITLE
修改地图翻译: ze_sky_fantasy_v2

### DIFF
--- a/2001/sharp/configs/translations/ze_sky_fantasy_v2.jsonc
+++ b/2001/sharp/configs/translations/ze_sky_fantasy_v2.jsonc
@@ -215,11 +215,9 @@
   },
   "-- 85 --": {
     "translation": "-- 85 --",
-    "blocked": true
   },
   "-- 50 --": {
     "translation": "-- 50 --",
-    "blocked": true
   },
   "-- STAGE I - EASY MODE --": {
     "translation": "-- 第一关-简单 --"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_sky_fantasy_v2
## 为什么要增加/修改这个东西
本图原翻译有两处错误的block使用，导致对应位置的倒计时无法正常显示，故申请去除对应翻译的block。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
