### PR TITLE
修改地图参数: ze_dreamin

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_dreamin.cfg
+++ b/2001/csgo/cfg/map-configs/ze_dreamin.cfg
@@ -168,13 +168,13 @@ ze_weapons_round_flash "1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "2"
+ze_weapons_round_adrenaline "3"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_dreamin
## 为什么要增加/修改这个东西
本图为四关跳刀+列车刀图，二三四关刀基本都是秒杀刀，boss技能还吃护甲，对萌新来说非常难打；地图场景较宽，黑洞雷作用非常有限，但少部分点位也可以有效降低人类守点压力。故申请增加血针数量，并重新加入黑洞雷，降低人类通关压力。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
