### PR TITLE
修改地图参数: ze_neron

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_neron.cfg
+++ b/2001/csgo/cfg/map-configs/ze_neron.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.1"
 
 
 ///
@@ -168,7 +168,7 @@ ze_weapons_round_flash "2"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_neron
## 为什么要增加/修改这个东西
本图为五关弹幕图，场景很宽，且有许多垂直结构的设计，四无关有秒杀弹幕，三四五关流程很长，不少点位守点难度较高，例如需要边守僵尸边跳小几十刀高低伤害刀，故重新给本图添加黑洞雷，并略微下调本图击退。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
