### PR TITLE
修改地图参数: ze_ffxii_mt_bur_omisace_v6

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_ffxii_mt_bur_omisace_v6.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffxii_mt_bur_omisace_v6.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.3"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.2"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.8"
+ze_cash_damage_zombie "1.0"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffxii_mt_bur_omisace_v6
## 为什么要增加/修改这个东西
本图地形设计较为宽敞且建议，防守路程短但时间要求长，人类经常团灭在火力守点上，僵尸无法有效击退，导致难度逐渐脱离地图设计好的神器对抗，变为纯火力守点图，故申请略微上调本体击退和打钱比。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
