### PR TITLE
修改地图数据: ze_bathroom

### DIFF
--- a/2001/sharp/configs/maps.json
+++ b/2001/sharp/configs/maps.json
@@ -357,7 +357,7 @@
     "nomination": true,
     "price": 300,
     "requiredOnline": -1,
-    "requiredPlayers": -1
+    "requiredPlayers": 25
   },
   "ze_beyond_the_boundary": {
     "admin": false,


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_bathroom
## 为什么要增加/修改这个东西
本图单关流程较短，且关末boss强度较高，人少开跑图模式时，若地图boss将人类团灭以后，会存在卡核爆和人类无限复活再吃核爆的情况，故申请增加本图预定人数要求，限制用本图作为暖服图。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
