### PR TITLE
修改地图通关奖励: ze_lotr_minas_tirith

### DIFF
--- a/2001/sharp/configs/rewards/ze_lotr_minas_tirith.jsonc
+++ b/2001/sharp/configs/rewards/ze_lotr_minas_tirith.jsonc
@@ -15,65 +15,65 @@
   "1": {
     "rankPasses": 7,
     "rankDamage": 18000,
-    "rankIntern": 0.4,
+    "rankIntern": 0.55,
     "econPasses": 4,
     "econDamage": 20000,
-    "econIntern": 0.2
+    "econIntern": 0.4
   },
   "2": {
     "rankPasses": 7,
-    "rankDamage": 10000,
-    "rankIntern": 0.4,
+    "rankDamage": 20000,
+    "rankIntern": 0.55,
     "econPasses": 4,
-    "econDamage": 20000,
-    "econIntern": 0.2
+    "econDamage": 24000,
+    "econIntern": 0.4
   },
   "3": {
     "rankPasses": 8,
     "rankDamage": 20000,
-    "rankIntern": 0.4,
+    "rankIntern": 0.55,
     "econPasses": 5,
     "econDamage": 24000,
-    "econIntern": 0.2
+    "econIntern": 0.4
   },
   "4": {
     "rankPasses": 9,
-    "rankDamage": 18000,
-    "rankIntern": 0.5,
+    "rankDamage": 20000,
+    "rankIntern": 0.55,
     "econPasses": 6,
     "econDamage": 24000,
-    "econIntern": 0.25
+    "econIntern": 0.4
   },
   "5": {
     "rankPasses": 9,
-    "rankDamage": 18000,
-    "rankIntern": 0.5,
+    "rankDamage": 20000,
+    "rankIntern": 0.55,
     "econPasses": 5,
-    "econDamage": 22000,
-    "econIntern": 0.25
+    "econDamage": 24000,
+    "econIntern": 0.4
   },
   "6": {
-    "rankPasses": 12,
-    "rankDamage": 18000,
-    "rankIntern": 0.5,
-    "econPasses": 8,
-    "econDamage": 22000,
-    "econIntern": 0.25
+    "rankPasses": 14,
+    "rankDamage": 20000,
+    "rankIntern": 0.55,
+    "econPasses": 10,
+    "econDamage": 24000,
+    "econIntern": 0.4
   },
   "7": {
     "rankPasses": 16,
-    "rankDamage": 18000,
-    "rankIntern": 0.6,
-    "econPasses": 12,
-    "econDamage": 22000,
-    "econIntern": 0.36
+    "rankDamage": 20000,
+    "rankIntern": 0.68,
+    "econPasses": 13,
+    "econDamage": 24000,
+    "econIntern": 0.5
   },
   "8": {
-    "rankPasses": 14,
-    "rankDamage": 18000,
-    "rankIntern": 0.5,
-    "econPasses": 10,
-    "econDamage": 22000,
-    "econIntern": 0.25
+    "rankPasses": 15,
+    "rankDamage": 20000,
+    "rankIntern": 0.68,
+    "econPasses": 12,
+    "econDamage": 24000,
+    "econIntern": 0.5
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_lotr_minas_tirith
## 为什么要增加/修改这个东西
根据地图关卡难度重新调整每一关通关奖励，且由于地图关卡时间较短，原失败低保过低，导致经常无法获取适量的失败低保，故调整本图部分关卡通关奖励和失败低保。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
