### PR TITLE
修改地图参数: ze_obj_blue_depth

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obj_blue_depth.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_blue_depth.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.3"
+ze_knockback_scale "1.1"
 
 ///
 /// Economy


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_blue_depth
## 为什么要增加/修改这个东西
根据近期开荒情况，该地图窄守点居多，击退太高导致僵尸方较为牢，故调整击退与其它同类型地图一致。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
