### PR TITLE
修改地图参数: ze_ffvii_mako_reactor_v6_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_ffvii_mako_reactor_v6_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffvii_mako_reactor_v6_p.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.15"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.2"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.0"
+ze_cash_damage_zombie "1.3"
 
 
 ///
@@ -150,7 +150,7 @@ ze_weapons_round_hegrenade "5"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "-1"
+ze_weapons_round_molotov "1"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "2"
+ze_weapons_round_adrenaline "3"
 
 
 ///
@@ -191,7 +191,7 @@ ze_skill_hunter_power "180.0"
 // 最小值: 1.05
 // 最大值: 1.55
 // 类  型: float
-ze_skill_faster_speed "1.2"
+ze_skill_faster_speed "1.3"
 
 // 说  明: 刀锋技能伤害 (unit)
 // 最小值: 40.0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffvii_mako_reactor_v6_p
## 为什么要增加/修改这个东西
当前地图参数设定不尽合理，由于地图点位设计完全没有刷分点，当前地图打钱比明显过低，萌新连买血针的钱都很难打到，手雷更是几乎难以购买，再加上boss机制较为困难，且有部分机制较为随机难以完全躲避，玩家需要更多的钱和道具去适应本图的设计，以便有更好的体验，故申请调高本图部分人类参数，与此同时作为平衡也略微降低本图击退和提高僵尸加速技能强度。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
