### PR TITLE
修改地图参数: ze_lotr_minas_tirith

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_lotr_minas_tirith.cfg
+++ b/2001/csgo/cfg/map-configs/ze_lotr_minas_tirith.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "0.9"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.0"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.7"
+ze_cash_damage_zombie "0.9"
 
 
 ///
@@ -126,7 +126,7 @@ ze_cash_damage_zombie "0.7"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_hegrenade "1"
+ze_weapons_spawn_hegrenade "3"
 
 // 说  明: 每局开始时补给的火瓶数量 (个)
 // 最小值: 0

--- a/2001/csgo/cfg/map-configs/ze_lotr_minas_tirith.cfg
+++ b/2001/csgo/cfg/map-configs/ze_lotr_minas_tirith.cfg
@@ -126,7 +126,7 @@ ze_cash_damage_zombie "0.9"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_hegrenade "3"
+ze_weapons_spawn_hegrenade "1"
 
 // 说  明: 每局开始时补给的火瓶数量 (个)
 // 最小值: 0
@@ -144,7 +144,7 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_hegrenade "1"
+ze_weapons_round_hegrenade "3"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_lotr_minas_tirith
## 为什么要增加/修改这个东西
本图当前由于圣光雷强度偏高，弹药神器发雷以后结合人类开枪，对僵尸的击退能力过强，很多关卡出现了卖人、甚至是有部分玩家恶意卖人以后人数很少还是能通关的情况，故申请调整本图几项参数，让地图强度对抗整体更加平衡。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
