### PR TITLE
修改地图通关奖励: ze_pirates_port_royal

### DIFF
--- a/2001/sharp/configs/rewards/ze_pirates_port_royal.jsonc
+++ b/2001/sharp/configs/rewards/ze_pirates_port_royal.jsonc
@@ -53,11 +53,11 @@
     "econIntern": 0.3
   },
   "6": {
-    "rankPasses": 15,
+    "rankPasses": 20,
     "rankDamage": 20000,
-    "rankIntern": 0.4,
-    "econPasses": 10,
+    "rankIntern": 0.5,
+    "econPasses": 15,
     "econDamage": 24000,
-    "econIntern": 0.3
+    "econIntern": 0.4
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_pirates_port_royal
## 为什么要增加/修改这个东西
本图第六关是前五关串在一起的ex关，难度高流程长，当前ex关通关奖励过低，故调整ex关通关奖励至合理数值。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
