### PR TITLE
修改地图参数: ze_rooftop_madness_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_rooftop_madness_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_rooftop_madness_p.cfg
@@ -36,7 +36,7 @@ mp_roundtime "20.0"
 // 最小值: 0
 // 最大值: 1
 // 类  型: int32
-mcr_map_extend_times "1"
+mcr_map_extend_times "0"
 
 // 说  明: VIP延长投票 (次)
 // 最小值: 0
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.15"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_rooftop_madness_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_rooftop_madness_p.cfg
@@ -115,7 +115,7 @@ ze_knockback_scale "1.15"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.8"
+ze_cash_damage_zombie "1.2"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_rooftop_madness_p
## 为什么要增加/修改这个东西
娱乐性质地图不易太多延长，因存在多条路/部分触发需要断后，故上调击退和打钱比
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
