### PR TITLE
修改地图通关奖励: ze_ffvii_mako_reactor_v6_p

### DIFF
--- a/2001/sharp/configs/rewards/ze_ffvii_mako_reactor_v6_p.jsonc
+++ b/2001/sharp/configs/rewards/ze_ffvii_mako_reactor_v6_p.jsonc
@@ -13,26 +13,26 @@
 
 {
   "1": {
-    "rankPasses": 8,
+    "rankPasses": 10,
     "rankDamage": 18000,
     "rankIntern": 0.4,
-    "econPasses": 5,
+    "econPasses": 8,
     "econDamage": 20000,
     "econIntern": 0.2
   },
   "2": {
-    "rankPasses": 8,
+    "rankPasses": 10,
     "rankDamage": 18000,
     "rankIntern": 0.4,
-    "econPasses": 6,
+    "econPasses": 8,
     "econDamage": 20000,
     "econIntern": 0.2
   },
   "3": {
-    "rankPasses": 9,
+    "rankPasses": 12,
     "rankDamage": 18000,
     "rankIntern": 0.4,
-    "econPasses": 6,
+    "econPasses": 8,
     "econDamage": 20000,
     "econIntern": 0.2
   },
@@ -45,10 +45,10 @@
     "econIntern": 0.56
   },
   "5": {
-    "rankPasses": 12,
+    "rankPasses": 15,
     "rankDamage": 18000,
     "rankIntern": 0.68,
-    "econPasses": 10,
+    "econPasses": 12,
     "econDamage": 20000,
     "econIntern": 0.56
   }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffvii_mako_reactor_v6_p
## 为什么要增加/修改这个东西
此地图难度标为入土难度，且地图含有大量神器和boss机制，守点难度较难，且目前通关奖励与其它同等级别地图不对等，故申请调整通关奖励。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
