### PR TITLE
修改地图参数: ze_predator_ultimate_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_predator_ultimate_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_predator_ultimate_p.cfg
@@ -115,7 +115,7 @@ ze_knockback_scale "1.0"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.6"
+ze_cash_damage_zombie "0.8"
 
 
 ///
@@ -150,7 +150,7 @@ ze_weapons_round_hegrenade "3"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "-1"
+ze_weapons_round_molotov "1"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
@@ -185,7 +185,7 @@ ze_weapons_round_adrenaline "1"
 // 最小值: 160.0
 // 最大值: 2000.0
 // 类  型: float
-ze_skill_hunter_power "300.0"
+ze_skill_hunter_power "260.0"
 
 // 说  明: 加速Boost (%)
 // 最小值: 1.05


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_predator_ultimate_p
## 为什么要增加/修改这个东西
当前地图闪灵已经被开发出许多非常难防守的点位，且某些点位并非人类一直开空枪就能完全守住的，导致目前一二关通关难度超出预期值，故下调闪灵推力和回调少数人类参数。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
