### PR TITLE
修改地图参数: ze_obf_rampage_v2_legacy

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obf_rampage_v2_legacy.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_rampage_v2_legacy.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.1"
+ze_knockback_scale "1.05"
 
 
 ///
@@ -185,13 +185,13 @@ ze_weapons_round_adrenaline "8"
 // 最小值: 160.0
 // 最大值: 2000.0
 // 类  型: float
-ze_skill_hunter_power "180.0"
+ze_skill_hunter_power "220.0"
 
 // 说  明: 加速Boost (%)
 // 最小值: 1.05
 // 最大值: 1.55
 // 类  型: float
-ze_skill_faster_speed "1.4"
+ze_skill_faster_speed "1.55"
 
 // 说  明: 刀锋技能伤害 (unit)
 // 最小值: 40.0
@@ -203,7 +203,7 @@ ze_skill_blader_damage "48.0"
 // 最小值: 3
 // 最大值: 10
 // 类  型: int32
-ze_skill_deimos_amount "5"
+ze_skill_deimos_amount "8"
 
 // 说  明: 赤焰技能伤害 (次)
 // 最小值: 1
@@ -227,7 +227,7 @@ ze_skill_farter_regen "5000"
 // 最小值: 72
 // 最大值: 256
 // 类  型: int32
-ze_skill_cirrus_range "96"
+ze_skill_cirrus_range "108"
 
 
 


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obf_rampage_v2_legacy
## 为什么要增加/修改这个东西
当前系列地图参数在火力对抗中比较利好人类，人类玩家体验好的同时，会让部分僵尸玩家的体验相对较差、力不从心。故调整本系列地图的地图参数，增强僵尸技能强度，提升僵尸的能力和玩家游玩体验。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
