### PR TITLE
修改地图翻译: ze_minecraft_sakura

### DIFF
--- a/2001/sharp/configs/translations/ze_minecraft_sakura.jsonc
+++ b/2001/sharp/configs/translations/ze_minecraft_sakura.jsonc
@@ -39,8 +39,8 @@
     "translation": "钓鱼台上的钻石块才是树屋开关!"
   },
   "(树屋将在60s后开放)": {
-    "translation": "树屋将在40秒后开放",
-    "countdown": 40
+    "translation": "树屋将在60秒后开放",
+    "countdown": 60
   },
   "(僵尸15秒后传送，开润！）": {
     "translation": "僵尸15秒后传送,开润!"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_minecraft_sakura
## 为什么要增加/修改这个东西
原地图翻译倒计时时长设置有误，故修正本图错误的倒计时。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
