### PR TITLE
修改地图参数: ze_ffvii_cosmo_canyon_t

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_ffvii_cosmo_canyon_t.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffvii_cosmo_canyon_t.cfg
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "-1"
+ze_weapons_round_adrenaline "2"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffvii_cosmo_canyon
## 为什么要增加/修改这个东西
因地图在boss阶段造成的伤害比雪cosmo的高，第四关的boss技能组致死率较高，故开放血针购买上限以提高通关容错率。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
