### PR TITLE
修改地图参数: ze_serpentis_temple

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_serpentis_temple.cfg
+++ b/2001/csgo/cfg/map-configs/ze_serpentis_temple.cfg
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_adrenaline "2"
+ze_weapons_round_adrenaline "3"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_serpentis_temple
## 为什么要增加/修改这个东西
自从调整石头伤害后，目前第五关打完boss之后躲石头的同时需要防备僵尸刀锋，血针两根经常在过桥时就已经用完。后续最后逃亡路无血针，非老司机玩家容易被石头砸死。故增加一根血针提高容错
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
