### PR TITLE
修改地图翻译: ze_obj_void_v1

### DIFF
--- a/2001/sharp/configs/translations/ze_obj_void_v1.jsonc
+++ b/2001/sharp/configs/translations/ze_obj_void_v1.jsonc
@@ -56,7 +56,8 @@
     "translation": "重新运作还得一会"
   },
   "Defend for 1 minutes": {
-    "translation": "大概60秒"
+    "translation": "大概60秒",
+    "countdown": 60
   },
   "Door opened": {
     "translation": "门开了"
@@ -102,12 +103,6 @@
   },
   "Hold the gate until the power comes back": {
     "translation": "电力正在恢复,守住"
-  },
-  "33%": {
-    "translation": "还有两处"
-  },
-  "66%": {
-    "translation": "还有一处"
   },
   "Its back! Run through the Door!": {
     "translation": "又来了,快穿过门"
@@ -317,7 +312,8 @@
     "translation": "发电机正在暖机"
   },
   "Resist for about 1 minute.": {
-    "translation": "需要大概60秒"
+    "translation": "需要大概60秒",
+    "countdown": 60
   },
   "The Generator is working! Get the hell out of here!": {
     "translation": "发电机启动了!快离开这里"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_void_v1
## 为什么要增加/修改这个东西
补充地图两处缺失倒计时，删除2个长期刷屏的无效地图提示。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
