### PR TITLE
修改地图数据: ze_obj_annihilate_dd_v1

### DIFF
--- a/2001/sharp/configs/maps.json
+++ b/2001/sharp/configs/maps.json
@@ -2412,7 +2412,7 @@
     "requiredPlayers": 50
   },
   "ze_obj_annihilate_dd_v1": {
-    "admin": true,
+    "admin": false,
     "certainTimes": [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
     "cooldown": 200,
     "nomination": true,


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_annihilate_dd_v1
## 为什么要增加/修改这个东西
开局传送bug已修复完毕，可正常开放玩家预订
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
