### PR TITLE
修改地图参数: ze_obj_annihilate_dd_v1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obj_annihilate_dd_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_annihilate_dd_v1.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "0.6"
+sv_falldamage_scale "0.0"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_annihilate_dd_v1
## 为什么要增加/修改这个东西
已跟地图作者商量，作者本意为地图应为取消摔伤，且部分高低差可造成触发手玩家/人类必经之路高额伤害，故关闭本图摔伤
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
