### PR TITLE
修改地图翻译: ze_obj_eclipsis

### DIFF
--- a/2001/sharp/configs/translations/ze_obj_eclipsis.jsonc
+++ b/2001/sharp/configs/translations/ze_obj_eclipsis.jsonc
@@ -57,8 +57,8 @@
     "translation": "看来我们只能从这边进入了"
   },
   "我们需要坚持40秒钟！": {
-    "translation": "我们需要坚持40秒钟!",
-    "countdown": 40
+    "translation": "我们需要坚持35秒钟!",
+    "countdown": 35
   },
   "小心两边的门": {
     "translation": "小心两边的门"
@@ -246,7 +246,7 @@
   },
   "给我35秒钟炸开他": {
     "translation": "给我35秒钟炸开他",
-    "countdown": 10
+    "countdown": 35
   },
   "这里有电！": {
     "translation": "这里有电!"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_eclipsis
## 为什么要增加/修改这个东西
修改一处地图门开的错误倒计时，修正一处倒计时翻译和countdown数值不对等问题
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
