### PR TITLE
修改地图参数: ze_obj_annihilate_dd_v1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obj_annihilate_dd_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_annihilate_dd_v1.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.35"
+ze_knockback_scale "1.5"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.35"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.1"
+ze_cash_damage_zombie "1.3"
 
 
 ///
@@ -162,13 +162,13 @@ ze_weapons_round_decoy "12"
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "3"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 10
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_annihilate_dd_v1
## 为什么要增加/修改这个东西
根据近期开荒情况表现为十分困难，本地图对标其它同类型地图难度直线上升，守点多为双门甚至三门守点，逃亡路需要大量道具支撑，故增强人类各项数值以让玩家优先度过开荒期。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
