### PR TITLE
修改地图通关奖励: ze_palace_of_minolila_cs2

### DIFF
--- a/2001/sharp/configs/rewards/ze_palace_of_minolila_cs2.jsonc
+++ b/2001/sharp/configs/rewards/ze_palace_of_minolila_cs2.jsonc
@@ -13,18 +13,18 @@
 
 {
   "1": {
-    "rankPasses": 7,
+    "rankPasses": 8,
     "rankDamage": 18000,
     "rankIntern": 0.42,
-    "econPasses": 4,
+    "econPasses": 5,
     "econDamage": 24000,
     "econIntern": 0.36
   },
   "2": {
-    "rankPasses": 7,
+    "rankPasses": 8,
     "rankDamage": 18000,
     "rankIntern": 0.42,
-    "econPasses": 4,
+    "econPasses": 5,
     "econDamage": 24000,
     "econIntern": 0.36
   },
@@ -37,7 +37,7 @@
     "econIntern": 0.36
   },
   "4": {
-    "rankPasses": 10,
+    "rankPasses": 12,
     "rankDamage": 18000,
     "rankIntern": 0.48,
     "econPasses": 8,
@@ -45,7 +45,7 @@
     "econIntern": 0.3
   },
   "5": {
-    "rankPasses": 12,
+    "rankPasses": 14,
     "rankDamage": 18000,
     "rankIntern": 0.48,
     "econPasses": 10,


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_palace_of_minolila_cs2
## 为什么要增加/修改这个东西
考虑到地图难度 酌情提高通关奖励；
其中第四第五关为跳刀关卡 难度偏高，提高基础云点和龙晶。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
