### PR TITLE
修改地图通关奖励: ze_ratatouille

### DIFF
--- a/2001/sharp/configs/rewards/ze_ratatouille.jsonc
+++ b/2001/sharp/configs/rewards/ze_ratatouille.jsonc
@@ -14,26 +14,26 @@
 {
   "1": {
     "rankPasses": 8,
-    "rankDamage": 18000,
+    "rankDamage": 20000,
     "rankIntern": 0.4,
     "econPasses": 6,
-    "econDamage": 20000,
+    "econDamage": 22000,
     "econIntern": 0.2
   },
   "2": {
     "rankPasses": 8,
-    "rankDamage": 18000,
+    "rankDamage": 20000,
     "rankIntern": 0.4,
     "econPasses": 6,
-    "econDamage": 20000,
+    "econDamage": 22000,
     "econIntern": 0.2
   },
   "3": {
     "rankPasses": 10,
-    "rankDamage": 18000,
+    "rankDamage": 20000,
     "rankIntern": 0.4,
     "econPasses": 8,
-    "econDamage": 20000,
+    "econDamage": 22000,
     "econIntern": 0.2
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ratatouille
## 为什么要增加/修改这个东西
该图刷分点过多，故提高伤害转化比以合理化通关奖励
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
