### PR TITLE
修改地图参数: ze_misaka2_reborn

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_misaka2_reborn.cfg
+++ b/2001/csgo/cfg/map-configs/ze_misaka2_reborn.cfg
@@ -70,7 +70,7 @@ ze_infect_sort_by_immunity "true"
 // 最小值: 1
 // 最大值: 64
 // 类  型: int32
-ze_infect_mother_ratio "7"
+ze_infect_mother_ratio "5"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: false
@@ -162,13 +162,13 @@ ze_weapons_round_decoy "2"
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "-1"
+ze_weapons_round_flash "1"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "1"
+ze_weapons_round_smoke "-1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_misaka2_reborn
## 为什么要增加/修改这个东西
由于僵尸阵营有一个开启后免疫子弹击退的神器，为增强双方阵营神器对抗性故禁用黑洞雷
考虑到部分关卡守点压力大，启用屏障雷的道具购买以缓解守点压力;
将尸变比由7更改为5以提高双方阵营的对抗强度，避免出现僵尸阵营方开局神器无法拾取全的可能性
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
