### PR TITLE
修改地图参数: ze_visualizer

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_visualizer.cfg
+++ b/2001/csgo/cfg/map-configs/ze_visualizer.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.4"
+ze_knockback_scale "1.6"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.4"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.9"
+ze_cash_damage_zombie "1.0"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_visualizer
## 为什么要增加/修改这个东西
当前系列地图参数偏低，导致实战中人类经常大比分战败，且本系列地图都是以弹幕结尾，萌新初见难以通关，故降低地图守点的火力成本和难度，提高本系列地图参数。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
