### PR TITLE
修改地图参数: ze_surf_hp

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_surf_hp.cfg
+++ b/2001/csgo/cfg/map-configs/ze_surf_hp.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "120"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "0.8"
+ze_knockback_scale "1.0"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "0.8"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.8"
+ze_cash_damage_zombie "1.0"
 
 
 ///
@@ -185,13 +185,13 @@ ze_weapons_round_adrenaline "2"
 // 最小值: 160.0
 // 最大值: 2000.0
 // 类  型: float
-ze_skill_hunter_power "180.0"
+ze_skill_hunter_power "220.0"
 
 // 说  明: 加速Boost (%)
 // 最小值: 1.05
 // 最大值: 2.00
 // 类  型: float
-ze_skill_faster_speed "1.4"
+ze_skill_faster_speed "1.5"
 
 // 说  明: 刀锋技能伤害 (unit)
 // 最小值: 40.0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_surf_hp
## 为什么要增加/修改这个东西
由于滑翔系列地图场景都非常宽敞，在默认的僵尸技能参数下很难发挥作用，故调高本系列地图僵尸技能参数，同时也略微调整人类参数，以更好地体现玩法。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
