### PR TITLE
修改地图通关奖励: ze_diverted_destiny

### DIFF
--- a/2001/sharp/configs/rewards/ze_diverted_destiny.jsonc
+++ b/2001/sharp/configs/rewards/ze_diverted_destiny.jsonc
@@ -21,12 +21,12 @@
     "econIntern": 0.21
   },
   "2": {
-    "rankPasses": 10,
-    "rankDamage": 20000,
-    "rankIntern": 0.42,
-    "econPasses": 7,
-    "econDamage": 22000,
-    "econIntern": 0.21
+    "rankPasses": 18,
+    "rankDamage": 25000,
+    "rankIntern": 0.55,
+    "econPasses": 14,
+    "econDamage": 28000,
+    "econIntern": 0.35
   },
   "3": {
     "rankPasses": 12,
@@ -37,11 +37,11 @@
     "econIntern": 0.21
   },
   "4": {
-    "rankPasses": 18,
-    "rankDamage": 22000,
-    "rankIntern": 0.4,
-    "econPasses": 9,
-    "econDamage": 24000,
-    "econIntern": 0.28
+    "rankPasses": 30,
+    "rankDamage": 28000,
+    "rankIntern": 0.55,
+    "econPasses": 20,
+    "econDamage": 30000,
+    "econIntern": 0.35
   }
 }

--- a/2001/sharp/configs/rewards/ze_diverted_destiny.jsonc
+++ b/2001/sharp/configs/rewards/ze_diverted_destiny.jsonc
@@ -39,7 +39,7 @@
   "4": {
     "rankPasses": 30,
     "rankDamage": 28000,
-    "rankIntern": 0.55,
+    "rankIntern": 0.5,
     "econPasses": 20,
     "econDamage": 30000,
     "econIntern": 0.35


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_diverted_destiny
## 为什么要增加/修改这个东西
第二、四关为长征类型，先前奖励过低。故调整对应通关奖励以及低保，以符合关卡难度
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
