### PR TITLE
修改地图数据: ze_arctic_escape_p

### DIFF
--- a/2001/sharp/configs/maps.json
+++ b/2001/sharp/configs/maps.json
@@ -198,7 +198,7 @@
     "requiredPlayers": 45
   },
   "ze_arctic_escape_p": {
-    "admin": true,
+    "admin": false,
     "certainTimes": [-1],
     "cooldown": 60,
     "nomination": false,


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_arctic_escape_p
## 为什么要增加/修改这个东西
大行动活动图，地图目前bug为核爆伤害不足，待海苔修复核爆伤害后方可正常开放预订。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
