### PR TITLE
修改地图参数: ze_obf_filth_v1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obf_filth_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_filth_v1.cfg
@@ -143,19 +143,19 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "12"
+ze_weapons_round_hegrenade "14"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "7"
+ze_weapons_round_molotov "9"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "5"
+ze_weapons_round_decoy "6"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obf_filth_v1
## 为什么要增加/修改这个东西
由于闪灵的增强可以做到在多个点位的闪灵大飞进攻点，导致人类通关难度直线上升，故增加人类道具量以抗衡僵尸进攻。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
