### PR TITLE
修改地图通关奖励: ze_descent_into_cerberon_p

### DIFF
--- a/2001/sharp/configs/rewards/ze_descent_into_cerberon_p.jsonc
+++ b/2001/sharp/configs/rewards/ze_descent_into_cerberon_p.jsonc
@@ -13,10 +13,10 @@
 
 {
   "1": {
-    "rankPasses": 3,
-    "rankDamage": 18000,
+    "rankPasses": 16,
+    "rankDamage": 25000,
     "rankIntern": 0.4,
-    "econPasses": 2,
+    "econPasses": 12,
     "econDamage": 20000,
     "econIntern": 0.2
   }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_descent_into_cerberon_p
## 为什么要增加/修改这个东西
该地图为接近20分钟的长征火力图,有一定的通关难度,故调高该图的通关奖励
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
