### PR TITLE
修改地图参数: ze_dnb_realms_a1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_dnb_realms_a1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_dnb_realms_a1.cfg
@@ -115,7 +115,7 @@ ze_knockback_scale "1.1"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.0"
+ze_cash_damage_zombie "0.9"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_dnb_realms_a1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_dnb_realms_a1.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "0.6"
+sv_falldamage_scale "0.5"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.1"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.8"
+ze_cash_damage_zombie "1.0"
 
 
 ///
@@ -132,7 +132,7 @@ ze_weapons_spawn_hegrenade "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_molotov "0"
+ze_weapons_spawn_molotov "1"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
@@ -156,13 +156,13 @@ ze_weapons_round_molotov "3"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "1"
+ze_weapons_round_decoy "3"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "1"
+ze_weapons_round_flash "2"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "2"
+ze_weapons_round_adrenaline "4"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_dnb_realms_a1
## 为什么要增加/修改这个东西
当前参数情况下通关率较为低迷，保证前半场景多个摔伤点后的容错率以及守点压力，酌情调整摔伤以及其他道具数量。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
