### PR TITLE
修改地图参数: ze_silent_hill_3_dawn_full

### DIFF
--- a/2001/csgo/cfg/map-configs/_extreme_ze_silent_hill_3_dawn_full.cfg
+++ b/2001/csgo/cfg/map-configs/_extreme_ze_silent_hill_3_dawn_full.cfg
@@ -93,7 +93,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "4"
+ze_weapons_round_adrenaline "7"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_silent_hill_3_dawn_full
## 为什么要增加/修改这个东西
第五关为前四关连打，存在多处摔伤点的前提下，若存在刀锋等僵尸，当前血针数量较为极限，常常在地图后半段就出现血针不够的情况，故增加血针数量
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
