### PR TITLE
修改地图通关奖励: ze_loom

### DIFF
--- a/2001/sharp/configs/rewards/ze_loom.jsonc
+++ b/2001/sharp/configs/rewards/ze_loom.jsonc
@@ -26,7 +26,7 @@
     "rankIntern": 0.4,
     "econPasses": 6,
     "econDamage": 22000,
-    "econIntern": 0.2
+    "econIntern": 0.3
   },
   "3": {
     "rankPasses": 10,

--- a/2001/sharp/configs/rewards/ze_loom.jsonc
+++ b/2001/sharp/configs/rewards/ze_loom.jsonc
@@ -14,25 +14,25 @@
 {
   "1": {
     "rankPasses": 6,
-    "rankDamage": 18000,
+    "rankDamage": 20000,
     "rankIntern": 0.4,
-    "econPasses": 4,
+    "econPasses": 6,
     "econDamage": 22000,
     "econIntern": 0.2
   },
   "2": {
-    "rankPasses": 6,
-    "rankDamage": 18000,
+    "rankPasses": 8,
+    "rankDamage": 20000,
     "rankIntern": 0.4,
-    "econPasses": 5,
+    "econPasses": 6,
     "econDamage": 22000,
     "econIntern": 0.2
   },
   "3": {
     "rankPasses": 10,
-    "rankDamage": 18000,
+    "rankDamage": 20000,
     "rankIntern": 0.6,
-    "econPasses": 6,
+    "econPasses": 8,
     "econDamage": 22000,
     "econIntern": 0.36
   }

--- a/2001/sharp/configs/rewards/ze_loom.jsonc
+++ b/2001/sharp/configs/rewards/ze_loom.jsonc
@@ -16,7 +16,7 @@
     "rankPasses": 6,
     "rankDamage": 20000,
     "rankIntern": 0.4,
-    "econPasses": 6,
+    "econPasses": 5,
     "econDamage": 22000,
     "econIntern": 0.2
   },


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_loom
## 为什么要增加/修改这个东西
该图整体设计非常容易迷路，僵尸神器就是模糊人类视野在撤退时的压力较大且上楼容易卡脚楼梯也多
第一关的撤退路是随机开的且需要去记路 有很多排列组合的方式容易记错路
第二关逃亡路压力非常大 且在逃亡路视野非常模糊一样容易走错路
第三关开局是人类随机传送两个传送点，而指挥只能带其中一条路且两个传送点的路都不好找，经常在开局就因为另一条路的人找不到路而失守团灭，在后续路中楼梯非常多需要大量道具去接人
当前奖励与实际难度有相差，调整通关奖励至正常数值

## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
