### PR TITLE
修改地图参数: ze_obf_rampage_v2

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obf_rampage_v2.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_rampage_v2.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.15"
+ze_knockback_scale "1.35"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.15"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.1"
+ze_cash_damage_zombie "1.2"
 
 
 ///
@@ -144,19 +144,19 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "14"
+ze_weapons_round_hegrenade "16"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "8"
+ze_weapons_round_molotov "12"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "7"
+ze_weapons_round_decoy "10"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obf_rampage_v2
## 为什么要增加/修改这个东西
根据开荒情况，人类在守点压力和经济上压力十分大，增强人类击退值 打钱比和道具购买量
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
