### PR TITLE
修改地图通关奖励: ze_minimal

### DIFF
--- a/2001/sharp/configs/rewards/ze_minimal.jsonc
+++ b/2001/sharp/configs/rewards/ze_minimal.jsonc
@@ -13,35 +13,35 @@
 
 {
   "1": {
-    "rankPasses": 7,
-    "rankDamage": 18000,
+    "rankPasses": 8,
+    "rankDamage": 15000,
     "rankIntern": 0.4,
-    "econPasses": 4,
-    "econDamage": 24000,
+    "econPasses": 5,
+    "econDamage": 20000,
     "econIntern": 0.2
   },
   "2": {
-    "rankPasses": 8,
-    "rankDamage": 18000,
+    "rankPasses": 9,
+    "rankDamage": 15000,
     "rankIntern": 0.4,
-    "econPasses": 4,
-    "econDamage": 24000,
+    "econPasses": 5,
+    "econDamage": 20000,
     "econIntern": 0.24
   },
   "3": {
     "rankPasses": 10,
-    "rankDamage": 18000,
+    "rankDamage": 15000,
     "rankIntern": 0.5,
     "econPasses": 6,
-    "econDamage": 24000,
+    "econDamage": 20000,
     "econIntern": 0.35
   },
   "4": {
     "rankPasses": 12,
-    "rankDamage": 18000,
+    "rankDamage": 15000,
     "rankIntern": 0.58,
     "econPasses": 8,
-    "econDamage": 24000,
+    "econDamage": 20000,
     "econIntern": 0.4
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_minimal
## 为什么要增加/修改这个东西
日常带图过程中发现现行奖励与地图难度不符，奖励与付出不成正比导致玩家流失严重，故调高奖励以增加玩家粘性
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
