### PR TITLE
修改地图参数: ze_sisyphus

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_sisyphus.cfg
+++ b/2001/csgo/cfg/map-configs/ze_sisyphus.cfg
@@ -64,7 +64,7 @@ sv_falldamage_scale "0.0"
 // 最小值: false
 // 最大值: true
 // 类  型: bool
-ze_infect_sort_by_immunity "true"
+ze_infect_sort_by_immunity "false"
 
 // 说  明: 尸变比 (人)
 // 最小值: 1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_sisyphus
## 为什么要增加/修改这个东西
由于此娱乐地图重赛次数频率高，会出现几名玩家连续尸变10回合以上的情况，故将尸变规则改为随机尸变。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
