### PR TITLE
修改地图参数: ze_dnb_realms_a1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_dnb_realms_a1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_dnb_realms_a1.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "0.5"
+sv_falldamage_scale "0.3"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_dnb_realms_a1
## 为什么要增加/修改这个东西
因此图第一场景流程较多高低差地形且不可规避，未选择防摔伤角色的萌新基本上不是大残就是摔死，前期两个大飞平台还会造成不等量的落地伤害，为减轻开局撤退负担，进一步削弱地图摔伤比
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
