### PR TITLE
修改地图通关奖励: ze_sisyphus

### DIFF
--- a/2001/sharp/configs/rewards/ze_sisyphus.jsonc
+++ b/2001/sharp/configs/rewards/ze_sisyphus.jsonc
@@ -15,65 +15,65 @@
   "1": {
     "rankPasses": 4,
     "rankDamage": 20000,
-    "rankIntern": 0.4,
+    "rankIntern": 0.45,
     "econPasses": 3,
     "econDamage": 24000,
-    "econIntern": 0.2
+    "econIntern": 0.25
   },
   "2": {
     "rankPasses": 4,
     "rankDamage": 20000,
-    "rankIntern": 0.4,
+    "rankIntern": 0.45,
     "econPasses": 3,
     "econDamage": 24000,
-    "econIntern": 0.2
+    "econIntern": 0.25
   },
   "3": {
     "rankPasses": 4,
     "rankDamage": 20000,
-    "rankIntern": 0.4,
+    "rankIntern": 0.45,
     "econPasses": 3,
     "econDamage": 24000,
-    "econIntern": 0.2
+    "econIntern": 0.25
   },
   "4": {
     "rankPasses": 4,
     "rankDamage": 20000,
-    "rankIntern": 0.4,
+    "rankIntern": 0.45,
     "econPasses": 3,
     "econDamage": 24000,
-    "econIntern": 0.2
+    "econIntern": 0.25
   },
   "5": {
     "rankPasses": 4,
     "rankDamage": 20000,
-    "rankIntern": 0.4,
+    "rankIntern": 0.45,
     "econPasses": 3,
     "econDamage": 24000,
-    "econIntern": 0.2
+    "econIntern": 0.25
   },
   "6": {
     "rankPasses": 6,
     "rankDamage": 20000,
-    "rankIntern": 0.4,
+    "rankIntern": 0.45,
     "econPasses": 4,
     "econDamage": 24000,
-    "econIntern": 0.2
+    "econIntern": 0.25
   },
   "7": {
     "rankPasses": 6,
     "rankDamage": 20000,
-    "rankIntern": 0.4,
+    "rankIntern": 0.45,
     "econPasses": 4,
     "econDamage": 24000,
-    "econIntern": 0.2
+    "econIntern": 0.25
   },
   "8": {
     "rankPasses": 6,
     "rankDamage": 30000,
-    "rankIntern": 0.4,
+    "rankIntern": 0.45,
     "econPasses": 4,
     "econDamage": 34000,
-    "econIntern": 0.2
+    "econIntern": 0.25
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_sisyphus
## 为什么要增加/修改这个东西
该地图为娱乐性质地图，奖励过高，且重赛多次低保奖励完全可盖过通关奖励，下调通关奖励，调整各关伤害结算比例，大部分玩家会一直刷僵尸，导致正常推进地图玩家消极游戏，故此做出修改确保该图为正常娱乐地图。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
