### PR TITLE
修改地图参数: ze_halloween_house_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_halloween_house_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_halloween_house_p.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "0.3"
+sv_falldamage_scale "0.0"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_halloween_house_p
## 为什么要增加/修改这个东西
在正常行径途中有极高摔伤点，腻滑油里满血摔下去的血量剩余40左右，但在对局中有刀锋的情况下死亡率极高，且金钱买道具不够买血针，故将0.3摔伤索性关闭以保证正常通关
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
