### PR TITLE
修改地图数据: ze_death_forest

### DIFF
--- a/2001/sharp/configs/maps.json
+++ b/2001/sharp/configs/maps.json
@@ -765,7 +765,7 @@
     "requiredPlayers": -1
   },
   "ze_death_forest": {
-    "admin": false,
+    "admin": true,
     "certainTimes": [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
     "cooldown": 120,
     "nomination": true,


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_death_forest
## 为什么要增加/修改这个东西
该地图有调关房能被玩家触发的问题，会影响对局的平衡和游玩玩家的体验，故暂时上锁等待地图修复
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
