### PR TITLE
修改地图参数: ze_diablo

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_diablo.cfg
+++ b/2001/csgo/cfg/map-configs/ze_diablo.cfg
@@ -19,7 +19,7 @@
 // 最小值: 1
 // 最大值: 70
 // 类  型: float
-mp_timelimit "60.0"
+mp_timelimit "70.0"
 
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.3"
 
 ///
 /// Economy
@@ -143,7 +143,7 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "9"
+ze_weapons_round_hegrenade 11"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_diablo.cfg
+++ b/2001/csgo/cfg/map-configs/ze_diablo.cfg
@@ -137,7 +137,7 @@ ze_weapons_spawn_molotov "0"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_decoy "1"
+ze_weapons_spawn_decoy "0"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
@@ -149,7 +149,7 @@ ze_weapons_round_hegrenade 11"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "3"
+ze_weapons_round_molotov "4"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_diablo
## 为什么要增加/修改这个东西
测图流程下来发现地图单局流程过长导致道具数量不够，
需增加地图时间以保证全流程通关。
测图结果少量增加击退和手雷道具数量，同时删除初始冰冻雷。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
