### PR TITLE
修改地图参数: ze_plants_vs_zombies

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_plants_vs_zombies.cfg
+++ b/2001/csgo/cfg/map-configs/ze_plants_vs_zombies.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.15"
+ze_knockback_scale "1.2"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_plants_vs_zombies.cfg
+++ b/2001/csgo/cfg/map-configs/ze_plants_vs_zombies.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.1"
+ze_knockback_scale "1.15"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.1"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.8"
+ze_cash_damage_zombie "0.9"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_plants_vs_zombies.cfg
+++ b/2001/csgo/cfg/map-configs/ze_plants_vs_zombies.cfg
@@ -25,7 +25,7 @@ mp_timelimit "50.0"
 // 最小值: 1
 // 最大值: 60
 // 类  型: float
-mp_roundtime "9.0"
+mp_roundtime "30.0"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_plants_vs_zombies.cfg
+++ b/2001/csgo/cfg/map-configs/ze_plants_vs_zombies.cfg
@@ -64,7 +64,7 @@ sv_falldamage_scale "0.0"
 // 最小值: false
 // 最大值: true
 // 类  型: bool
-ze_infect_sort_by_immunity "true"
+ze_infect_sort_by_immunity "false"
 
 // 说  明: 尸变比 (人)
 // 最小值: 1

--- a/2001/csgo/cfg/map-configs/ze_plants_vs_zombies.cfg
+++ b/2001/csgo/cfg/map-configs/ze_plants_vs_zombies.cfg
@@ -25,7 +25,7 @@ mp_timelimit "50.0"
 // 最小值: 1
 // 最大值: 60
 // 类  型: float
-mp_roundtime "30.0"
+mp_roundtime "9.0"
 
 
 ///
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.25"
+ze_knockback_scale "1.1"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.25"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.0"
+ze_cash_damage_zombie "0.8"
 
 
 ///
@@ -132,13 +132,13 @@ ze_weapons_spawn_hegrenade "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_molotov "1"
+ze_weapons_spawn_molotov "0"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_decoy "1"
+ze_weapons_spawn_decoy "0"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_plants_vs_zombies.cfg
+++ b/2001/csgo/cfg/map-configs/ze_plants_vs_zombies.cfg
@@ -82,7 +82,7 @@ ze_infect_teleport_to_spawn "true"
 // 最小值: 10
 // 最大值: 90
 // 类  型: int32
-ze_infect_mother_spawn_time "20"
+ze_infect_mother_spawn_time "15"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_plants_vs_zombies
## 为什么要增加/修改这个东西
测试结果下来,降低部分击退、减少打钱比率、删除初始冰冻类以平衡双方对抗强度;
修改回合时长为9分钟
考虑到地图为神器对抗图,开启随机尸变以避免卡尸变指数
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
