### PR TITLE
修改地图参数: ze_voodoo_xtrem_islands

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_voodoo_xtrem_islands.cfg
+++ b/2001/csgo/cfg/map-configs/ze_voodoo_xtrem_islands.cfg
@@ -19,7 +19,7 @@
 // 最小值: 1
 // 最大值: 70
 // 类  型: float
-mp_timelimit "50.0"
+mp_timelimit "30.0"
 
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
@@ -42,7 +42,7 @@ mcr_map_extend_times "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-vip_map_extend_times "1"
+vip_map_extend_times "0"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_voodoo_xtrem_islands
## 为什么要增加/修改这个东西
近期出现很多指挥在此简单图不以通关为目的,专门带人去非常规点位或者卖人打法导致简单图多次重赛，导致出现很多人恶意尸变甚至指挥带头尸变的情况出现,并不以通关为目的拉延长，一张简单图打一个多小时的情况时有发生，申请减少地图时间并取消vip延长
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
