### PR TITLE
修改地图参数: ze_plants_vs_zombies

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_plants_vs_zombies.cfg
+++ b/2001/csgo/cfg/map-configs/ze_plants_vs_zombies.cfg
@@ -82,7 +82,7 @@ ze_infect_teleport_to_spawn "true"
 // 最小值: 10
 // 最大值: 90
 // 类  型: int32
-ze_infect_mother_spawn_time "15"
+ze_infect_mother_spawn_time "10"
 
 
 ///
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.1"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.2"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.9"
+ze_cash_damage_zombie "0.8"
 
 
 ///
@@ -156,7 +156,7 @@ ze_weapons_round_molotov "4"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "3"
+ze_weapons_round_decoy "-1"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_plants_vs_zombies
## 为什么要增加/修改这个东西
结合最近多次以7-1 7-0的比分,适当下调击退至1.1和打钱比例;
删除冰冻手雷以避免"丢冰续传"的情况;
调整尸变时间比以避免尸变时传送导致的神器丢失
(开局场景存在防感染,10秒尸变不影响)
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
