### PR TITLE
修改地图参数: ze_epstein_island

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_epstein_island.cfg
+++ b/2001/csgo/cfg/map-configs/ze_epstein_island.cfg
@@ -25,7 +25,7 @@ mp_timelimit "60.0"
 // 最小值: 1
 // 最大值: 60
 // 类  型: float
-mp_roundtime "20.0"
+mp_roundtime "35.0"
 
 
 ///
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.5"
 
 
 ///
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "3"
+ze_weapons_round_adrenaline "5"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_epstein_island
## 为什么要增加/修改这个东西
开荒期目前参数通关较为困难,故调整击退以及血针数。第四/六关回合基础时间较长，调整回合时间以便可以在开荒时有充足时间
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
