### PR TITLE
修改地图参数: ze_backrooms_insomnia

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_backrooms_insomnia.cfg
+++ b/2001/csgo/cfg/map-configs/ze_backrooms_insomnia.cfg
@@ -115,7 +115,7 @@ ze_knockback_scale "1.6"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.0"
+ze_cash_damage_zombie "1.2"
 
 
 ///
@@ -144,13 +144,13 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "7"
+ze_weapons_round_hegrenade "10"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "4"
+ze_weapons_round_molotov "6"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_backrooms_insomnia
## 为什么要增加/修改这个东西
level0最后一个点，5个人丢黑洞都能守住，把其他人全卖了，而且该图有断后神器，故删除黑洞；击退整体过高，僵尸神器操作了也接近不了杀不死人，故修改击退
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
