### PR TITLE
修改地图参数: ze_samosbor

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_samosbor.cfg
+++ b/2001/csgo/cfg/map-configs/ze_samosbor.cfg
@@ -126,7 +126,7 @@ ze_cash_damage_zombie "1.2"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_hegrenade "2"
+ze_weapons_spawn_hegrenade "1"
 
 // 说  明: 每局开始时补给的火瓶数量 (个)
 // 最小值: 0

--- a/2001/csgo/cfg/map-configs/ze_samosbor.cfg
+++ b/2001/csgo/cfg/map-configs/ze_samosbor.cfg
@@ -115,7 +115,7 @@ ze_knockback_scale "2.0"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.0"
+ze_cash_damage_zombie "1.2"
 
 
 ///
@@ -126,7 +126,7 @@ ze_cash_damage_zombie "1.0"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_hegrenade "1"
+ze_weapons_spawn_hegrenade "2"
 
 // 说  明: 每局开始时补给的火瓶数量 (个)
 // 最小值: 0
@@ -144,25 +144,25 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "15"
+ze_weapons_round_hegrenade "18"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "10"
+ze_weapons_round_molotov "13"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "6"
+ze_weapons_round_decoy "-1"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "1"
+ze_weapons_round_flash "2"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_samosbor
## 为什么要增加/修改这个东西
地图更新后，作者删除了诱饵雷导致冰冻弹失效，故删除冰冻雷/增加部分道具数量以及打钱比，以缓解人类压力
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
