### PR TITLE
修改地图参数: ze_depths

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_depths.cfg
+++ b/2001/csgo/cfg/map-configs/ze_depths.cfg
@@ -126,31 +126,31 @@ ze_cash_damage_zombie "1.2"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_hegrenade "1"
+ze_weapons_spawn_hegrenade "2"
 
 // 说  明: 每局开始时补给的火瓶数量 (个)
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_molotov "1"
+ze_weapons_spawn_molotov "2"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_decoy "0"
+ze_weapons_spawn_decoy "1"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "14"
+ze_weapons_round_hegrenade "12"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "5"
+ze_weapons_round_molotov "6"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_depths
## 为什么要增加/修改这个东西
根据该图近期游玩情况，经常出现在第三关开局双路崩溃，且该图三关的开局都是宽守点第三关甚至涉及到双路高低差守点，故增加开局道具数量，调整可购买道具数量。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
