### PR TITLE
修改地图参数: ze_timesink

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_timesink.cfg
+++ b/2001/csgo/cfg/map-configs/ze_timesink.cfg
@@ -115,7 +115,7 @@ ze_knockback_scale "1.6"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.0"
+ze_cash_damage_zombie "1.2"
 
 
 ///
@@ -126,13 +126,13 @@ ze_cash_damage_zombie "1.0"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_hegrenade "1"
+ze_weapons_spawn_hegrenade "2"
 
 // 说  明: 每局开始时补给的火瓶数量 (个)
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_molotov "1"
+ze_weapons_spawn_molotov "2"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0


### PR DESCRIPTION

## 该PR作用的地图是(仅英文小写)
ze_timesink
## 为什么要增加/修改这个东西
根据近期情况 该图打钱比偏低，因为该图都是宽守点开局压力巨大经常开局崩溃故提高开局的初始雷与火
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
