### PR TITLE
修改地图参数: ze_arknights_caerula_arbor

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_arknights_caerula_arbor.cfg
+++ b/2001/csgo/cfg/map-configs/ze_arknights_caerula_arbor.cfg
@@ -162,7 +162,7 @@ ze_weapons_round_decoy "1"
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "0"
+ze_weapons_round_flash "-1"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_arknights_caerula_arbor.cfg
+++ b/2001/csgo/cfg/map-configs/ze_arknights_caerula_arbor.cfg
@@ -162,7 +162,7 @@ ze_weapons_round_decoy "1"
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "1"
+ze_weapons_round_flash "0"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_arknights_caerula_arbor
## 为什么要增加/修改这个东西
该图作为一张神器对抗图屏障雷在一些贴门守点过于强势能左右局势，且该图打法已经成熟，故删除屏障雷。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
