### PR TITLE
修改地图通关奖励: ze_parkour

### DIFF
--- a/2001/sharp/configs/rewards/ze_parkour.jsonc
+++ b/2001/sharp/configs/rewards/ze_parkour.jsonc
@@ -14,10 +14,10 @@
 {
   "1": {
     "rankPasses": 6,
-    "rankDamage": 22000,
+    "rankDamage": 38000,
     "rankIntern": 0.6,
     "econPasses": 3,
-    "econDamage": 25000,
+    "econDamage": 40000,
     "econIntern": 0.35
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_parkour
## 为什么要增加/修改这个东西
地图更改传送点导致人类刷传送点，分数偏高，申请降低刷分奖励获取
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
