### PR TITLE
修改地图通关奖励: ze_palace_of_minolila_cs2

### DIFF
--- a/2001/sharp/configs/rewards/ze_palace_of_minolila_cs2.jsonc
+++ b/2001/sharp/configs/rewards/ze_palace_of_minolila_cs2.jsonc
@@ -16,7 +16,7 @@
     "rankPasses": 11,
     "rankDamage": 18000,
     "rankIntern": 0.48,
-    "econPasses": 7,
+    "econPasses": 5,
     "econDamage": 24000,
     "econIntern": 0.38
   },
@@ -24,7 +24,7 @@
     "rankPasses": 12,
     "rankDamage": 18000,
     "rankIntern": 0.48,
-    "econPasses": 7,
+    "econPasses": 5,
     "econDamage": 24000,
     "econIntern": 0.38
   },
@@ -32,7 +32,7 @@
     "rankPasses": 14,
     "rankDamage": 18000,
     "rankIntern": 0.58,
-    "econPasses": 9,
+    "econPasses": 6,
     "econDamage": 24000,
     "econIntern": 0.36
   },
@@ -40,17 +40,17 @@
     "rankPasses": 16,
     "rankDamage": 18000,
     "rankIntern": 0.68,
-    "econPasses": 12,
+    "econPasses": 7,
     "econDamage": 24000,
-    "econIntern": 0.48
+    "econIntern": 0.42
   },
   "5": {
     "rankPasses": 18,
     "rankDamage": 18000,
     "rankIntern": 0.68,
-    "econPasses": 12,
+    "econPasses": 7,
     "econDamage": 24000,
-    "econIntern": 0.48
+    "econIntern": 0.42
   },
   "6": {
     "rankPasses": 5,

--- a/2001/sharp/configs/rewards/ze_palace_of_minolila_cs2.jsonc
+++ b/2001/sharp/configs/rewards/ze_palace_of_minolila_cs2.jsonc
@@ -13,47 +13,47 @@
 
 {
   "1": {
-    "rankPasses": 8,
+    "rankPasses": 11,
     "rankDamage": 18000,
-    "rankIntern": 0.42,
-    "econPasses": 5,
+    "rankIntern": 0.48,
+    "econPasses": 7,
     "econDamage": 24000,
-    "econIntern": 0.36
+    "econIntern": 0.38
   },
   "2": {
-    "rankPasses": 8,
+    "rankPasses": 12,
     "rankDamage": 18000,
-    "rankIntern": 0.42,
-    "econPasses": 5,
+    "rankIntern": 0.48,
+    "econPasses": 7,
     "econDamage": 24000,
-    "econIntern": 0.36
+    "econIntern": 0.38
   },
   "3": {
-    "rankPasses": 9,
+    "rankPasses": 14,
     "rankDamage": 18000,
-    "rankIntern": 0.42,
-    "econPasses": 5,
+    "rankIntern": 0.58,
+    "econPasses": 9,
     "econDamage": 24000,
     "econIntern": 0.36
   },
   "4": {
-    "rankPasses": 12,
+    "rankPasses": 16,
     "rankDamage": 18000,
-    "rankIntern": 0.48,
-    "econPasses": 8,
-    "econDamage": 20000,
-    "econIntern": 0.3
+    "rankIntern": 0.68,
+    "econPasses": 12,
+    "econDamage": 24000,
+    "econIntern": 0.48
   },
   "5": {
-    "rankPasses": 14,
+    "rankPasses": 18,
     "rankDamage": 18000,
-    "rankIntern": 0.48,
-    "econPasses": 10,
-    "econDamage": 20000,
-    "econIntern": 0.3
+    "rankIntern": 0.68,
+    "econPasses": 12,
+    "econDamage": 24000,
+    "econIntern": 0.48
   },
   "6": {
-    "rankPasses": 4,
+    "rankPasses": 5,
     "rankDamage": 20000,
     "rankIntern": 0.35,
     "econPasses": 3,


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_palace_of_minolila_cs2
## 为什么要增加/修改这个东西
考虑到近期该地图游玩热度较低,修改地图通关奖励以提高游玩热度;
考虑到地图关卡难度,提高低保奖励,确保最大情况下不超过通关奖励的80%
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
