### PR TITLE
修改地图通关奖励: ze_sky_fantasy_v2

### DIFF
--- a/2001/sharp/configs/rewards/ze_sky_fantasy_v2.jsonc
+++ b/2001/sharp/configs/rewards/ze_sky_fantasy_v2.jsonc
@@ -13,44 +13,44 @@
 
 {
   "1": {
-    "rankPasses": 7,
-    "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 4,
+    "rankPasses": 10,
+    "rankDamage": 20000,
+    "rankIntern": 0.48,
+    "econPasses": 6,
     "econDamage": 24000,
-    "econIntern": 0.2
+    "econIntern": 0.38
   },
   "2": {
-    "rankPasses": 7,
-    "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 5,
+    "rankPasses": 12,
+    "rankDamage": 20000,
+    "rankIntern": 0.48,
+    "econPasses": 8,
     "econDamage": 24000,
     "econIntern": 0.2
   },
   "3": {
-    "rankPasses": 8,
-    "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 6,
-    "econDamage": 24000,
-    "econIntern": 0.2
-  },
-  "4": {
-    "rankPasses": 10,
-    "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 8,
-    "econDamage": 24000,
-    "econIntern": 0.2
-  },
-  "5": {
     "rankPasses": 12,
     "rankDamage": 18000,
-    "rankIntern": 0.4,
+    "rankIntern": 0.48,
     "econPasses": 8,
     "econDamage": 24000,
-    "econIntern": 0.28
+    "econIntern": 0.38
+  },
+  "4": {
+    "rankPasses": 15,
+    "rankDamage": 18000,
+    "rankIntern": 0.52,
+    "econPasses": 11,
+    "econDamage": 24000,
+    "econIntern": 0.4
+  },
+  "5": {
+    "rankPasses": 18,
+    "rankDamage": 18000,
+    "rankIntern": 0.52,
+    "econPasses": 12,
+    "econDamage": 24000,
+    "econIntern": 0.42
   },
   "6": {
     "rankPasses": 4,


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_sky_fantasy_v2
## 为什么要增加/修改这个东西
考虑到地图近期游玩频率极低,上调部分通关奖励从而匹配地图难度;
考虑到关卡4/5难度与前3关跨度较大,大幅提高4/5两关奖励,
同时提高所有关卡低保以确保低保不超过各个关卡通关奖励的80%
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
