### PR TITLE
修改地图通关奖励: ze_2049

### DIFF
--- a/2001/sharp/configs/rewards/ze_2049.jsonc
+++ b/2001/sharp/configs/rewards/ze_2049.jsonc
@@ -16,16 +16,16 @@
     "rankPasses": 14,
     "rankDamage": 20000,
     "rankIntern": 0.48,
-    "econPasses": 10,
+    "econPasses": 6,
     "econDamage": 24000,
-    "econIntern": 0.42
+    "econIntern": 0.35
   },
   "2": {
     "rankPasses": 18,
     "rankDamage": 20000,
     "rankIntern": 0.48,
-    "econPasses": 11,
+    "econPasses": 7,
     "econDamage": 24000,
-    "econIntern": 0.42
+    "econIntern": 0.38
   }
 }

--- a/2001/sharp/configs/rewards/ze_2049.jsonc
+++ b/2001/sharp/configs/rewards/ze_2049.jsonc
@@ -13,19 +13,19 @@
 
 {
   "1": {
-    "rankPasses": 9,
-    "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 6,
-    "econDamage": 20000,
-    "econIntern": 0.2
+    "rankPasses": 14,
+    "rankDamage": 20000,
+    "rankIntern": 0.48,
+    "econPasses": 10,
+    "econDamage": 24000,
+    "econIntern": 0.42
   },
   "2": {
-    "rankPasses": 12,
-    "rankDamage": 18000,
+    "rankPasses": 18,
+    "rankDamage": 20000,
     "rankIntern": 0.48,
-    "econPasses": 7,
+    "econPasses": 11,
     "econDamage": 24000,
-    "econIntern": 0.36
+    "econIntern": 0.42
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_2049
## 为什么要增加/修改这个东西
关卡1最后为上升低重力躲避弹幕,考虑到难度以及先前回合守点压力提高该关卡和奖励;
关卡2打完boss后存在kz逃亡路.考虑到在该情况下多次重赛,且期间boss掉人过多,大幅提高通关奖励和低保;
两关提高低保同时已确保不超过通关奖励的80%.
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
