### PR TITLE
修改地图通关奖励: ze_dreamin

### DIFF
--- a/2001/sharp/configs/rewards/ze_dreamin.jsonc
+++ b/2001/sharp/configs/rewards/ze_dreamin.jsonc
@@ -13,28 +13,28 @@
 
 {
   "1": {
-    "rankPasses": 8,
+    "rankPasses": 14,
     "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 5,
-    "econDamage": 20000,
-    "econIntern": 0.2
+    "rankIntern": 0.48,
+    "econPasses": 10,
+    "econDamage": 24000,
+    "econIntern": 0.38
   },
   "2": {
-    "rankPasses": 8,
+    "rankPasses": 14,
     "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 5,
-    "econDamage": 20000,
-    "econIntern": 0.2
+    "rankIntern": 0.48,
+    "econPasses": 10,
+    "econDamage": 24000,
+    "econIntern": 0.38
   },
   "3": {
-    "rankPasses": 9,
+    "rankPasses": 18,
     "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 6,
-    "econDamage": 20000,
-    "econIntern": 0.2
+    "rankIntern": 0.58,
+    "econPasses": 12,
+    "econDamage": 24000,
+    "econIntern": 0.48
   },
   "4": {
     "rankPasses": 10,


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_dreamin
## 为什么要增加/修改这个东西
提高1/2/3关地图通关奖励和低保 低保确保不超过地图通关奖励80%;
第1关存在高低刀+地坠刀;第2关存在列车刀+高低刀;第3关存在竖刀+横刀以及二阶段回头秒杀刀;
考虑到地图难度大幅调整通关奖励.
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
