### PR TITLE
修改地图通关奖励: ze_ffxii_feywood_t

### DIFF
--- a/2001/sharp/configs/rewards/ze_ffxii_feywood_t.jsonc
+++ b/2001/sharp/configs/rewards/ze_ffxii_feywood_t.jsonc
@@ -13,31 +13,31 @@
 
 {
   "1": {
-    "rankPasses": 8,
+    "rankPasses": 10,
     "rankDamage": 20000,
     "rankIntern": 0.6,
-    "econPasses": 5,
+    "econPasses": 7,
     "econDamage": 24000,
     "econIntern": 0.5
   },
   "2": {
-    "rankPasses": 8,
+    "rankPasses": 10,
     "rankDamage": 20000,
     "rankIntern": 0.6,
-    "econPasses": 6,
+    "econPasses": 7,
     "econDamage": 24000,
     "econIntern": 0.45
   },
   "3": {
-    "rankPasses": 8,
+    "rankPasses": 10,
     "rankDamage": 20000,
     "rankIntern": 0.6,
-    "econPasses": 6,
+    "econPasses": 7,
     "econDamage": 24000,
     "econIntern": 0.45
   },
   "4": {
-    "rankPasses": 12,
+    "rankPasses": 13,
     "rankDamage": 20000,
     "rankIntern": 0.8,
     "econPasses": 9,
@@ -45,7 +45,7 @@
     "econIntern": 0.6
   },
   "5": {
-    "rankPasses": 14,
+    "rankPasses": 17,
     "rankDamage": 20000,
     "rankIntern": 0.8,
     "econPasses": 11,


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffxii_feywood_t
## 为什么要增加/修改这个东西
依据地图难度重新调整通关奖励,确保低保不超过通关奖励的80%;
同时针对跳刀关卡提高过图收益.
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
