### PR TITLE
修改地图通关奖励: ze_ffxii_ridorana_cataract

### DIFF
--- a/2001/sharp/configs/rewards/ze_ffxii_ridorana_cataract.jsonc
+++ b/2001/sharp/configs/rewards/ze_ffxii_ridorana_cataract.jsonc
@@ -13,35 +13,35 @@
 
 {
   "1": {
-    "rankPasses": 8,
-    "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 6,
-    "econDamage": 20000,
-    "econIntern": 0.2
-  },
-  "2": {
-    "rankPasses": 8,
-    "rankDamage": 18000,
-    "rankIntern": 0.48,
-    "econPasses": 6,
-    "econDamage": 20000,
-    "econIntern": 0.24
-  },
-  "3": {
     "rankPasses": 10,
     "rankDamage": 18000,
     "rankIntern": 0.6,
-    "econPasses": 8,
-    "econDamage": 20000,
+    "econPasses": 6,
+    "econDamage": 24000,
     "econIntern": 0.42
   },
-  "4": {
+  "2": {
     "rankPasses": 12,
     "rankDamage": 18000,
     "rankIntern": 0.6,
-    "econPasses": 10,
-    "econDamage": 20000,
-    "econIntern": 0.42
+    "econPasses": 6,
+    "econDamage": 24000,
+    "econIntern": 0.58
+  },
+  "3": {
+    "rankPasses": 15,
+    "rankDamage": 18000,
+    "rankIntern": 0.6,
+    "econPasses": 12,
+    "econDamage": 24000,
+    "econIntern": 0.5
+  },
+  "4": {
+    "rankPasses": 18,
+    "rankDamage": 20000,
+    "rankIntern": 0.6,
+    "econPasses": 13,
+    "econDamage": 24000,
+    "econIntern": 0.5
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffxii_ridorana_cataract
## 为什么要增加/修改这个东西
重新调整通关奖励和低保从而匹配地图难度;
针对难度较大关卡上调地图通关奖励,同时保证低保不超过通关奖励80%
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
