### PR TITLE
修改地图通关奖励: ze_hsc

### DIFF
--- a/2001/sharp/configs/rewards/ze_hsc.jsonc
+++ b/2001/sharp/configs/rewards/ze_hsc.jsonc
@@ -13,27 +13,27 @@
 
 {
   "1": {
-    "rankPasses": 8,
-    "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 5,
-    "econDamage": 24000,
-    "econIntern": 0.2
-  },
-  "2": {
-    "rankPasses": 9,
-    "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 8,
-    "econDamage": 22000,
-    "econIntern": 0.24
-  },
-  "3": {
     "rankPasses": 11,
     "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 10,
+    "rankIntern": 0.6,
+    "econPasses": 7,
+    "econDamage": 24000,
+    "econIntern": 0.48
+  },
+  "2": {
+    "rankPasses": 13,
+    "rankDamage": 18000,
+    "rankIntern": 0.68,
+    "econPasses": 9,
+    "econDamage": 22000,
+    "econIntern": 0.52
+  },
+  "3": {
+    "rankPasses": 17,
+    "rankDamage": 18000,
+    "rankIntern": 0.8,
+    "econPasses": 11,
     "econDamage": 23000,
-    "econIntern": 0.24
+    "econIntern": 0.6
   }
 }

--- a/2001/sharp/configs/rewards/ze_hsc.jsonc
+++ b/2001/sharp/configs/rewards/ze_hsc.jsonc
@@ -16,24 +16,24 @@
     "rankPasses": 11,
     "rankDamage": 18000,
     "rankIntern": 0.6,
-    "econPasses": 7,
+    "econPasses": 5,
     "econDamage": 24000,
-    "econIntern": 0.48
+    "econIntern": 0.4
   },
   "2": {
     "rankPasses": 13,
     "rankDamage": 18000,
     "rankIntern": 0.68,
-    "econPasses": 9,
+    "econPasses": 6,
     "econDamage": 22000,
-    "econIntern": 0.52
+    "econIntern": 0.4
   },
   "3": {
     "rankPasses": 17,
     "rankDamage": 18000,
     "rankIntern": 0.8,
-    "econPasses": 11,
+    "econPasses": 7,
     "econDamage": 23000,
-    "econIntern": 0.6
+    "econIntern": 0.4
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_hsc
## 为什么要增加/修改这个东西
重新调整通关奖励从而匹配地图关卡难度,确保低保不超过通关奖励80%
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
