### PR TITLE
修改地图通关奖励: ze_lego

### DIFF
--- a/2001/sharp/configs/rewards/ze_lego.jsonc
+++ b/2001/sharp/configs/rewards/ze_lego.jsonc
@@ -13,11 +13,11 @@
 
 {
   "1": {
-    "rankPasses": 30,
+    "rankPasses": 35,
     "rankDamage": 35000,
-    "rankIntern": 0.8,
-    "econPasses": 25,
+    "rankIntern": 0.9,
+    "econPasses": 28,
     "econDamage": 38000,
-    "econIntern": 0.6
+    "econIntern": 0.7
   }
 }

--- a/2001/sharp/configs/rewards/ze_lego.jsonc
+++ b/2001/sharp/configs/rewards/ze_lego.jsonc
@@ -15,9 +15,9 @@
   "1": {
     "rankPasses": 35,
     "rankDamage": 35000,
-    "rankIntern": 0.9,
+    "rankIntern": 0.8,
     "econPasses": 28,
     "econDamage": 38000,
-    "econIntern": 0.7
+    "econIntern": 0.6
   }
 }

--- a/2001/sharp/configs/rewards/ze_lego.jsonc
+++ b/2001/sharp/configs/rewards/ze_lego.jsonc
@@ -15,9 +15,9 @@
   "1": {
     "rankPasses": 30,
     "rankDamage": 35000,
-    "rankIntern": 0.42,
+    "rankIntern": 0.8,
     "econPasses": 25,
     "econDamage": 38000,
-    "econIntern": 0.28
+    "econIntern": 0.6
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_lego
## 为什么要增加/修改这个东西
考虑到地图存在连关和存档机制,触发存档时并不会获得通关奖励;
调整地图通关奖励和低保,保证在非连关情况下不会功亏一篑.
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
