### PR TITLE
修改地图通关奖励: ze_mist_p

### DIFF
--- a/2001/sharp/configs/rewards/ze_mist_p.jsonc
+++ b/2001/sharp/configs/rewards/ze_mist_p.jsonc
@@ -15,9 +15,9 @@
   "1": {
     "rankPasses": 16,
     "rankDamage": 20000,
-    "rankIntern": 0.7,
-    "econPasses": 12,
+    "rankIntern": 0.68,
+    "econPasses": 7,
     "econDamage": 24000,
-    "econIntern": 0.5
+    "econIntern": 0.4
   }
 }

--- a/2001/sharp/configs/rewards/ze_mist_p.jsonc
+++ b/2001/sharp/configs/rewards/ze_mist_p.jsonc
@@ -13,11 +13,11 @@
 
 {
   "1": {
-    "rankPasses": 12,
-    "rankDamage": 18000,
-    "rankIntern": 0.5,
-    "econPasses": 8,
+    "rankPasses": 16,
+    "rankDamage": 20000,
+    "rankIntern": 0.7,
+    "econPasses": 12,
     "econDamage": 24000,
-    "econIntern": 0.36
+    "econIntern": 0.5
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_mist_p
## 为什么要增加/修改这个东西
单关极难弹幕图,考虑到近期在该地图上通关耗时,提高通关奖励和低保;
确保低保不超过通关奖励80%
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
