### PR TITLE
修改地图通关奖励: ze_cyberspace_v2

### DIFF
--- a/2001/sharp/configs/rewards/ze_cyberspace_v2.jsonc
+++ b/2001/sharp/configs/rewards/ze_cyberspace_v2.jsonc
@@ -13,26 +13,26 @@
 
 {
   "1": {
-    "rankPasses": 6,
+    "rankPasses": 9,
     "rankDamage": 18000,
     "rankIntern": 0.4,
-    "econPasses": 4,
+    "econPasses": 6,
     "econDamage": 20000,
     "econIntern": 0.24
   },
   "2": {
-    "rankPasses": 7,
+    "rankPasses": 12,
     "rankDamage": 18000,
     "rankIntern": 0.4,
-    "econPasses": 4,
+    "econPasses": 9,
     "econDamage": 21000,
     "econIntern": 0.24
   },
   "3": {
-    "rankPasses": 10,
+    "rankPasses": 14,
     "rankDamage": 18000,
     "rankIntern": 0.48,
-    "econPasses": 7,
+    "econPasses": 10,
     "econDamage": 22000,
     "econIntern": 0.24
   },


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_cyberspace_v2
## 为什么要增加/修改这个东西
本图作为火力弹幕图，三关均存在大量分路高压守点及大断口，第二关有地坠弹幕，第三关有boss战及高压逃亡路；对火力及玩家实力要求较高，故调高123关的奖励
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
