### PR TITLE
修改地图Boss: ze_stilshrine_of_miriam

### DIFF
--- a/2001/sharp/configs/bosses/ze_stilshrine_of_miriam.jsonc
+++ b/2001/sharp/configs/bosses/ze_stilshrine_of_miriam.jsonc
@@ -24,8 +24,8 @@
   "Counters": [
     {
       "iterator": "Stage4_Boss_Bergan_HP_Main",
-      "backup": "Stage4_Boss_Bergan_HP_Middle",
       "counter": "Stage4_Boss_Bergan_HP_End",
+      "mass": 100,
       "hitbox": "Stage4_Boss_Bergan_Phys_Body",
       "display": "Bergan"
     },
@@ -37,7 +37,7 @@
     {
       "iterator": "Stage3_End_Guard_HP",
       "hitbox": "Stage3_End_Guard_Phys",
-      "display": "Guard"
+      "display": "Mateus"
     },
     {
       "iterator": "Stage4_Ending_Bergan_HP",
@@ -46,22 +46,22 @@
     },
     {
       "iterator": "Mateus_Health_HP_Main",
-      "backup": "Mateus_Health_Middle",
       "counter": "Mateus_Health_End",
+      "mass": 73,
       "hitbox": "Stage3_Mateus_Phys_Body",
       "display": "Mateus"
     },
     {
       "iterator": "Dragon_Aevis_Health_HP_Main",
-      "backup": "Dragon_Aevis_Health_Middle",
       "counter": "Dragon_Aevis_Health_End",
+      "mass": 55,
       "hitbox": "Dragon_Aevis_Phys_Body",
       "display": "Aevis"
     },
     {
       "iterator": "Stage-1_Gabranth_HP_Main",
-      "backup": "Stage-1_Gabranth_HP_Middle",
       "counter": "Stage-1_Gabranth_HP_End",
+      "mass": 55,
       "hitbox": "Stage-1_Gabranth_Phys_Body",
       "display": "Gabranth"
     },
@@ -74,7 +74,7 @@
   "Monsters": [
     {
       "identity": "2018",
-      "display": "Mini"
+      "display": "Cactus"
     }
   ]
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_stilshrine_of_miriam

## 为什么要增加/修改这个东西
Boss血量系统每个阶段会重新计算血量而不是传统三个counter系统。这会修复错误血量显示。我也顺便修改boss名字。

## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
