### PR TITLE
修改地图通关奖励: ze_aot_trost_v6r

### DIFF
--- a/2001/sharp/configs/rewards/ze_aot_trost_v6r.jsonc
+++ b/2001/sharp/configs/rewards/ze_aot_trost_v6r.jsonc
@@ -14,42 +14,42 @@
 {
   "1": {
     "rankPasses": 9,
-    "rankDamage": 12000,
+    "rankDamage": 14000,
     "rankIntern": 0.4,
     "econPasses": 7,
-    "econDamage": 14000,
+    "econDamage": 16000,
     "econIntern": 0.35
   },
   "2": {
     "rankPasses": 9,
-    "rankDamage": 12000,
+    "rankDamage": 14000,
     "rankIntern": 0.4,
     "econPasses": 7,
-    "econDamage": 14000,
+    "econDamage": 16000,
     "econIntern": 0.35
   },
   "3": {
     "rankPasses": 10,
-    "rankDamage": 12000,
-    "rankIntern": 0.4,
+    "rankDamage": 14000,
+    "rankIntern": 0.45,
     "econPasses": 8,
-    "econDamage": 14000,
-    "econIntern": 0.35
+    "econDamage": 16000,
+    "econIntern": 0.4
   },
   "4": {
-    "rankPasses": 12,
-    "rankDamage": 12000,
-    "rankIntern": 0.4,
-    "econPasses": 10,
-    "econDamage": 14000,
-    "econIntern": 0.35
+    "rankPasses": 14,
+    "rankDamage": 14000,
+    "rankIntern": 0.5,
+    "econPasses": 12,
+    "econDamage": 16000,
+    "econIntern": 0.45
   },
   "5": {
-    "rankPasses": 14,
-    "rankDamage": 12000,
-    "rankIntern": 0.45,
-    "econPasses": 12,
-    "econDamage": 14000,
-    "econIntern": 0.35
+    "rankPasses": 16,
+    "rankDamage": 14000,
+    "rankIntern": 0.5,
+    "econPasses": 14,
+    "econDamage": 16000,
+    "econIntern": 0.45
   }
 }

--- a/2001/sharp/configs/rewards/ze_aot_trost_v6r.jsonc
+++ b/2001/sharp/configs/rewards/ze_aot_trost_v6r.jsonc
@@ -13,43 +13,43 @@
 
 {
   "1": {
-    "rankPasses": 8,
+    "rankPasses": 9,
     "rankDamage": 12000,
     "rankIntern": 0.4,
-    "econPasses": 6,
-    "econDamage": 15000,
-    "econIntern": 0.2
+    "econPasses": 7,
+    "econDamage": 14000,
+    "econIntern": 0.35
   },
   "2": {
-    "rankPasses": 8,
+    "rankPasses": 9,
     "rankDamage": 12000,
     "rankIntern": 0.4,
-    "econPasses": 6,
-    "econDamage": 15000,
-    "econIntern": 0.2
+    "econPasses": 7,
+    "econDamage": 14000,
+    "econIntern": 0.35
   },
   "3": {
     "rankPasses": 10,
-    "rankDamage": 16000,
+    "rankDamage": 12000,
     "rankIntern": 0.4,
     "econPasses": 8,
-    "econDamage": 20000,
-    "econIntern": 0.2
+    "econDamage": 14000,
+    "econIntern": 0.35
   },
   "4": {
-    "rankPasses": 10,
-    "rankDamage": 16000,
-    "rankIntern": 0.4,
-    "econPasses": 8,
-    "econDamage": 20000,
-    "econIntern": 0.24
-  },
-  "5": {
     "rankPasses": 12,
     "rankDamage": 12000,
-    "rankIntern": 0.42,
-    "econPasses": 8,
-    "econDamage": 15000,
-    "econIntern": 0.24
+    "rankIntern": 0.4,
+    "econPasses": 10,
+    "econDamage": 14000,
+    "econIntern": 0.35
+  },
+  "5": {
+    "rankPasses": 14,
+    "rankDamage": 12000,
+    "rankIntern": 0.45,
+    "econPasses": 12,
+    "econDamage": 14000,
+    "econIntern": 0.35
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_aot_trost_v6r
## 为什么要增加/修改这个东西
整体调整奖励，以匹配该图难度，因第四，五关为高强度神器对抗，故额外提高基础和低保，以匹配关卡难度和提高过关积极性。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
