### PR TITLE
修改地图通关奖励: ze_s_a_m

### DIFF
--- a/2001/sharp/configs/rewards/ze_s_a_m.jsonc
+++ b/2001/sharp/configs/rewards/ze_s_a_m.jsonc
@@ -45,10 +45,10 @@
     "econIntern": 0.55
   },
   "5": {
-    "rankPasses": 12,
+    "rankPasses": 15,
     "rankDamage": 18000,
     "rankIntern": 0.65,
-    "econPasses": 10,
+    "econPasses": 12,
     "econDamage": 20000,
     "econIntern": 0.55
   }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_s_a_m
## 为什么要增加/修改这个东西
本图第五关为14~15min，因通关奖励过低导致人类方在最后一个点失败时出现低保奖励比例过高无法吃分的情况，根据实际情况调整地图通关奖励，已核对过奖励比例。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
