### PR TITLE
修改地图参数: ze_amdaporkeep

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_amdaporkeep.cfg
+++ b/2001/csgo/cfg/map-configs/ze_amdaporkeep.cfg
@@ -144,13 +144,13 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "6"
+ze_weapons_round_hegrenade "4"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "3"
+ze_weapons_round_molotov "2"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "4"
+ze_weapons_round_adrenaline "2"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_amdaporkeep
## 为什么要增加/修改这个东西
地图开荒后给的参数经过观察道具给的过多,减少道具量
血针给的过多,给两根针已经可以保证某些情况下萌新可以存活,多余血针删除.
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
