### PR TITLE
修改地图参数: ze_minecraft_dreamland

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_minecraft_dreamland.cfg
+++ b/2001/csgo/cfg/map-configs/ze_minecraft_dreamland.cfg
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "6"
+ze_weapons_round_adrenaline "7"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_minecraft_dreamland.cfg
+++ b/2001/csgo/cfg/map-configs/ze_minecraft_dreamland.cfg
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "3"
+ze_weapons_round_adrenaline "6"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_minecraft_dreamland
## 为什么要增加/修改这个东西
僵尸zm火球可对人类造成巨大的血量压力，考虑到这点，故提高血针上限为6根。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
