### PR TITLE
修改地图参数: ze_hr_dead_center

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_hr_dead_center.cfg
+++ b/2001/csgo/cfg/map-configs/ze_hr_dead_center.cfg
@@ -19,7 +19,7 @@
 // 最小值: 1
 // 最大值: 70
 // 类  型: float
-mp_timelimit "45.0"
+mp_timelimit "35.0"
 
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
@@ -36,13 +36,13 @@ mp_roundtime "30"
 // 最小值: 0
 // 最大值: 1
 // 类  型: int32
-mcr_map_extend_times "1"
+mcr_map_extend_times "0"
 
 // 说  明: VIP延长投票 (次)
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-vip_map_extend_times "2"
+vip_map_extend_times "1"
 
 
 ///
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.1"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_hr_dead_center
## 为什么要增加/修改这个东西
根据开荒情况调整击退，由于连关模式特殊机制，地图需要手动RTV，故调整地图时间防止游玩时间过长
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
