### PR TITLE
修改地图通关奖励: ze_tranquility

### DIFF
--- a/2001/sharp/configs/rewards/ze_tranquility.jsonc
+++ b/2001/sharp/configs/rewards/ze_tranquility.jsonc
@@ -13,18 +13,18 @@
 
 {
   "1": {
-    "rankPasses": 16,
-    "rankDamage": 26000,
+    "rankPasses": 12,
+    "rankDamage": 28000,
     "rankIntern": 0.5,
-    "econPasses": 14,
-    "econDamage": 28000,
+    "econPasses": 10,
+    "econDamage": 30000,
     "econIntern": 0.45
   },
   "2": {
-    "rankPasses": 12,
+    "rankPasses": 10,
     "rankDamage": 26000,
     "rankIntern": 0.4,
-    "econPasses": 10,
+    "econPasses": 8,
     "econDamage": 28000,
     "econIntern": 0.35
   }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_tranquility
## 为什么要增加/修改这个东西
实战中时间与预估时间不合，实际为15分钟左右第一关，故整体提高刷分比，降低基础奖励，保持低保。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
