### PR TITLE
修改地图参数: ze_last_man_standing

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_last_man_standing.cfg
+++ b/2001/csgo/cfg/map-configs/ze_last_man_standing.cfg
@@ -70,7 +70,7 @@ ze_infect_sort_by_immunity "true"
 // 最小值: 1
 // 最大值: 64
 // 类  型: int32
-ze_infect_mother_ratio "7"
+ze_infect_mother_ratio "4"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: false
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.16"
+ze_knockback_scale "0.8"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_last_man_standing
## 为什么要增加/修改这个东西
僵尸过少，人类击退过高，本图僵尸血量为脚本控制，僵尸不会超过10000血，故修改尸变比和人类击退以加强僵尸方，测试两次全是一把过
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
