### PR TITLE
修改地图参数: ze_surf_operation_deterioration

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_surf_operation_deterioration.cfg
+++ b/2001/csgo/cfg/map-configs/ze_surf_operation_deterioration.cfg
@@ -162,13 +162,13 @@ ze_weapons_round_decoy "12"
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "3"
+ze_weapons_round_flash "5"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "5"
+ze_weapons_round_smoke "3"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_surf_operation_deterioration.cfg
+++ b/2001/csgo/cfg/map-configs/ze_surf_operation_deterioration.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.25"
+ze_knockback_scale "1.65"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.25"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.1"
+ze_cash_damage_zombie "1.2"
 
 
 ///
@@ -144,31 +144,31 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "18"
+ze_weapons_round_hegrenade "24"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "10"
+ze_weapons_round_molotov "15"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "9"
+ze_weapons_round_decoy "12"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "1"
+ze_weapons_round_flash "3"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "1"
+ze_weapons_round_smoke "5"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1
@@ -185,7 +185,7 @@ ze_weapons_round_adrenaline "5"
 // 最小值: 160.0
 // 最大值: 2000.0
 // 类  型: float
-ze_skill_hunter_power "300.0"
+ze_skill_hunter_power "180.0"
 
 // 说  明: 加速Boost (%)
 // 最小值: 1.05


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)

## 为什么要增加/修改这个东西

经跑图测试，修改以下参数：
1. 地图守点压力大，故调整道具数量以及打钱比
2. 经跑图测试发现，僵尸不易打退，故提高击退参数（跑图测试过程调整为 1.65 后，能够正常击退僵尸）
3. 闪灵推力过大，导致过于容易大飞破点，故降低闪灵推力


## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
