### PR TITLE
修改地图通关奖励: ze_parkour

### DIFF
--- a/2001/sharp/configs/rewards/ze_parkour.jsonc
+++ b/2001/sharp/configs/rewards/ze_parkour.jsonc
@@ -13,7 +13,7 @@
 
 {
   "1": {
-    "rankPasses": 4,
+    "rankPasses": 5,
     "rankDamage": 40000,
     "rankIntern": 0.6,
     "econPasses": 3,

--- a/2001/sharp/configs/rewards/ze_parkour.jsonc
+++ b/2001/sharp/configs/rewards/ze_parkour.jsonc
@@ -13,11 +13,11 @@
 
 {
   "1": {
-    "rankPasses": 6,
-    "rankDamage": 38000,
+    "rankPasses": 4,
+    "rankDamage": 40000,
     "rankIntern": 0.6,
     "econPasses": 3,
-    "econDamage": 40000,
+    "econDamage": 42000,
     "econIntern": 0.35
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_parkour
## 为什么要增加/修改这个东西
该地图流程三分半，且传送打法存在2分钟的僵尸传送刷分点，故调整奖励
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
