### PR TITLE
修改地图参数: ze_eternal_grove

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_eternal_grove.cfg
+++ b/2001/csgo/cfg/map-configs/ze_eternal_grove.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.1"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_eternal_grove.cfg
+++ b/2001/csgo/cfg/map-configs/ze_eternal_grove.cfg
@@ -185,7 +185,7 @@ ze_weapons_round_adrenaline "4"
 // 最小值: 160.0
 // 最大值: 2000.0
 // 类  型: float
-ze_skill_hunter_power "200.0"
+ze_skill_hunter_power "180.0"
 
 // 说  明: 加速Boost (%)
 // 最小值: 1.05

--- a/2001/csgo/cfg/map-configs/ze_eternal_grove.cfg
+++ b/2001/csgo/cfg/map-configs/ze_eternal_grove.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.0"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.2"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.8"
+ze_cash_damage_zombie "0.75"
 
 
 ///
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "5"
+ze_weapons_round_adrenaline "4"
 
 
 ///
@@ -185,7 +185,7 @@ ze_weapons_round_adrenaline "5"
 // 最小值: 160.0
 // 最大值: 2000.0
 // 类  型: float
-ze_skill_hunter_power "180.0"
+ze_skill_hunter_power "200.0"
 
 // 说  明: 加速Boost (%)
 // 最小值: 1.05

--- a/2001/csgo/cfg/map-configs/ze_eternal_grove.cfg
+++ b/2001/csgo/cfg/map-configs/ze_eternal_grove.cfg
@@ -115,7 +115,7 @@ ze_knockback_scale "1.0"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.75"
+ze_cash_damage_zombie "0.8"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_eternal_grove
## 为什么要增加/修改这个东西
结合测试参数实战下来,调整测试参数,
下调人类方的击退(1.2->1.1);
下调1根血针(5->4).

## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
