### PR TITLE
修改地图通关奖励: ze_eternal_grove

### DIFF
--- a/2001/sharp/configs/rewards/ze_eternal_grove.jsonc
+++ b/2001/sharp/configs/rewards/ze_eternal_grove.jsonc
@@ -13,10 +13,10 @@
 
 {
   "1": {
-    "rankPasses": 28,
+    "rankPasses": 30,
     "rankDamage": 30000,
     "rankIntern": 0.6,
-    "econPasses": 18,
+    "econPasses": 20,
     "econDamage": 34000,
     "econIntern": 0.4
   }

--- a/2001/sharp/configs/rewards/ze_eternal_grove.jsonc
+++ b/2001/sharp/configs/rewards/ze_eternal_grove.jsonc
@@ -13,10 +13,10 @@
 
 {
   "1": {
-    "rankPasses": 35,
+    "rankPasses": 28,
     "rankDamage": 30000,
     "rankIntern": 0.6,
-    "econPasses": 24,
+    "econPasses": 18,
     "econDamage": 34000,
     "econIntern": 0.4
   }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_eternal_grove
## 为什么要增加/修改这个东西
下调地图通关奖励;
(云点35->30)(龙晶24->20)
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
