### PR TITLE
修改地图参数: ze_trainsanity

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_trainsanity.cfg
+++ b/2001/csgo/cfg/map-configs/ze_trainsanity.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.15"
+ze_knockback_scale "1.2"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_trainsanity.cfg
+++ b/2001/csgo/cfg/map-configs/ze_trainsanity.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.1"
 
 
 ///
@@ -162,7 +162,7 @@ ze_weapons_round_decoy "5"
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "1"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_trainsanity.cfg
+++ b/2001/csgo/cfg/map-configs/ze_trainsanity.cfg
@@ -115,7 +115,7 @@ ze_knockback_scale "1.1"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.2"
+ze_cash_damage_zombie "1.35"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_trainsanity.cfg
+++ b/2001/csgo/cfg/map-configs/ze_trainsanity.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.4"
+ze_knockback_scale "1.15"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.4"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.25"
+ze_cash_damage_zombie "1.2"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_trainsanity
## 为什么要增加/修改这个东西
经实战，击退偏高，全员飞虎神鹰，僵尸难以操作，使地图偏简单，故降低击退和提高打钱比，和削减人类对屏障的依赖性，提高地图守点对抗性。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
