### PR TITLE
修改地图参数: ze_candyfactory

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_candyfactory.cfg
+++ b/2001/csgo/cfg/map-configs/ze_candyfactory.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.25"
+ze_knockback_scale "1.45"
 
 ///
 /// Economy
@@ -114,7 +114,7 @@ ze_knockback_scale "1.25"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.0"
+ze_cash_damage_zombie "1.35"
 
 
 ///
@@ -143,25 +143,25 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "8"
+ze_weapons_round_hegrenade "14"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "5"
+ze_weapons_round_molotov "8"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "3"
+ze_weapons_round_decoy "5"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "1"
+ze_weapons_round_flash "2"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
@@ -173,7 +173,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "4"
+ze_weapons_round_adrenaline "6"
 
 
 ///
@@ -190,13 +190,13 @@ ze_skill_hunter_power "180.0"
 // 最小值: 1.05
 // 最大值: 2.00
 // 类  型: float
-ze_skill_faster_speed "1.45"
+ze_skill_faster_speed "1.4"
 
 // 说  明: 刀锋技能伤害 (unit)
 // 最小值: 48.0
 // 最大值: 1000.0
 // 类  型: float
-ze_skill_blader_damage "48.0"
+ze_skill_blader_damage "64.0"
 
 // 说  明: 恶魔技能连锁次数 (次)
 // 最小值: 3


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_candyfactory
## 为什么要增加/修改这个东西
地图整体难度较高，尤其第四关的分路滑翔加陷阱过多，故需要提高人类击退和打钱比和道具量来应对，同时恢复僵尸基本参数。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
