### PR TITLE
修改地图参数: ze_hr_dead_center

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_hr_dead_center.cfg
+++ b/2001/csgo/cfg/map-configs/ze_hr_dead_center.cfg
@@ -19,7 +19,7 @@
 // 最小值: 1
 // 最大值: 70
 // 类  型: float
-mp_timelimit "35.0"
+mp_timelimit "25.0"
 
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
@@ -191,7 +191,7 @@ ze_skill_hunter_power "200.0"
 // 最小值: 1.05
 // 最大值: 2.00
 // 类  型: float
-ze_skill_faster_speed "1.4"
+ze_skill_faster_speed "1.5"
 
 // 说  明: 刀锋技能伤害 (unit)
 // 最小值: 48.0
@@ -221,7 +221,7 @@ ze_skill_dancer_speed "0.6"
 // 最小值: 1000
 // 最大值: 100000
 // 类  型: int32
-ze_skill_farter_regen "5000"
+ze_skill_farter_regen "1000"
 
 // 说  明: 长手僵尸攻击射程 (unit)
 // 最小值: 96


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_hr_dead_center
## 为什么要增加/修改这个东西
由于地图特性，每一关特殊场景僵尸都会低血量，屁王僵尸回血较强导致通关较为困难，故调整参数至合理范围。同时调整地图时间和加速僵尸，提高对抗性以及避免游玩地图过长
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
