### PR TITLE
修改地图通关奖励: ze_rtcw_ominous_rumors_p

### DIFF
--- a/2001/sharp/configs/rewards/ze_rtcw_ominous_rumors_p.jsonc
+++ b/2001/sharp/configs/rewards/ze_rtcw_ominous_rumors_p.jsonc
@@ -13,27 +13,27 @@
 
 {
   "1": {
-    "rankPasses": 6,
-    "rankDamage": 18000,
+    "rankPasses": 5,
+    "rankDamage": 24000,
     "rankIntern": 0.4,
     "econPasses": 4,
-    "econDamage": 20000,
+    "econDamage": 28000,
     "econIntern": 0.2
   },
   "2": {
     "rankPasses": 6,
-    "rankDamage": 18000,
+    "rankDamage": 24000,
     "rankIntern": 0.4,
-    "econPasses": 5,
-    "econDamage": 20000,
+    "econPasses": 4,
+    "econDamage": 28000,
     "econIntern": 0.2
   },
   "3": {
     "rankPasses": 7,
-    "rankDamage": 18000,
+    "rankDamage": 24000,
     "rankIntern": 0.4,
-    "econPasses": 5,
-    "econDamage": 20000,
+    "econPasses": 4,
+    "econDamage": 28000,
     "econIntern": 0.2
   },
   "4": {
@@ -46,42 +46,42 @@
   },
   "5": {
     "rankPasses": 6,
-    "rankDamage": 18000,
+    "rankDamage": 24000,
     "rankIntern": 0.4,
-    "econPasses": 5,
-    "econDamage": 20000,
+    "econPasses": 4,
+    "econDamage": 28000,
     "econIntern": 0.2
   },
   "6": {
     "rankPasses": 7,
-    "rankDamage": 18000,
+    "rankDamage": 24000,
     "rankIntern": 0.4,
-    "econPasses": 5,
-    "econDamage": 20000,
+    "econPasses": 4,
+    "econDamage": 28000,
     "econIntern": 0.2
   },
   "7": {
     "rankPasses": 6,
-    "rankDamage": 18000,
+    "rankDamage": 24000,
     "rankIntern": 0.4,
     "econPasses": 4,
-    "econDamage": 20000,
+    "econDamage": 28000,
     "econIntern": 0.2
   },
   "8": {
-    "rankPasses": 6,
-    "rankDamage": 18000,
+    "rankPasses": 7,
+    "rankDamage": 24000,
     "rankIntern": 0.4,
-    "econPasses": 5,
-    "econDamage": 20000,
+    "econPasses": 4,
+    "econDamage": 28000,
     "econIntern": 0.2
   },
   "9": {
-    "rankPasses": 7,
-    "rankDamage": 18000,
+    "rankPasses": 8,
+    "rankDamage": 24000,
     "rankIntern": 0.4,
     "econPasses": 5,
-    "econDamage": 20000,
+    "econDamage": 28000,
     "econIntern": 0.2
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
 ze_rtcw_ominous_rumors_p
## 为什么要增加/修改这个东西
考虑地图实际难度,前1-5关较为简单,且有常守刷分点,
下调通关奖励,同时提高云点和龙晶的伤害转化比.
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
