### PR TITLE
修改地图参数: ze_basic_geometric

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_basic_geometric.cfg
+++ b/2001/csgo/cfg/map-configs/ze_basic_geometric.cfg
@@ -25,7 +25,7 @@ mp_timelimit "45.0"
 // 最小值: 1
 // 最大值: 60
 // 类  型: float
-mp_roundtime "30.0"
+mp_roundtime "60.0"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_basic_geometric.cfg
+++ b/2001/csgo/cfg/map-configs/ze_basic_geometric.cfg
@@ -42,7 +42,7 @@ mcr_map_extend_times "0"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-vip_map_extend_times "1"
+vip_map_extend_times "2"
 
 
 ///
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.4"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.2"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.8"
+ze_cash_damage_zombie "1.25"
 
 
 ///
@@ -144,37 +144,37 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "5"
+ze_weapons_round_hegrenade "12"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "3"
+ze_weapons_round_molotov "8"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "2"
+ze_weapons_round_decoy "4"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "3"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "1"
+ze_weapons_round_smoke "2"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "3"
+ze_weapons_round_adrenaline "6"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_basic_geometric
## 为什么要增加/修改这个东西
地图新增第二关，原参数已不再适配，第二关触发难度较高，失误会导致回合时间30分钟不够，故提高回合时间至60。
地图有几处僵尸容易破点的守点，且地图含多处空降追尾，地形宽阔守点，故提高参数，增加黑洞雷和屏障雷的数量应对第二关。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
