### PR TITLE
补充地图通关奖励: ze_ffxii_westersand_v8

### DIFF
--- a/2001/sharp/configs/rewards/ze_ffxii_westersand_v8.jsonc
+++ b/2001/sharp/configs/rewards/ze_ffxii_westersand_v8.jsonc
@@ -45,10 +45,10 @@
     "econIntern": 0.55
   },
   "5": {
-    "rankPasses": 12,
+    "rankPasses": 5,
     "rankDamage": 18000,
     "rankIntern": 0.42,
-    "econPasses": 10,
+    "econPasses": 3,
     "econDamage": 20000,
     "econIntern": 0.35
   },
@@ -74,6 +74,14 @@
     "rankIntern": 0.65,
     "econPasses": 10,
     "econDamage": 20000,
+    "econIntern": 0.55
+  },
+  "9": {
+    "rankPasses": 16,
+    "rankDamage": 18000,
+    "rankIntern": 0.65,
+    "econPasses": 10,
+    "econDamage": 24000,
     "econIntern": 0.55
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffxii_westersand_v8
## 为什么要增加/修改这个东西
GOD-INSANE 关卡奖励补充.
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
