### PR TITLE
修改地图参数: ze_obj_multimaps

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obj_avulsion_a1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_avulsion_a1.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.55"
+ze_knockback_scale "1.35"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.55"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.4"
+ze_cash_damage_zombie "1.2"
 
 
 ///
@@ -168,7 +168,7 @@ ze_weapons_round_flash "3"
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_obj_blue_depth.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_blue_depth.cfg
@@ -167,7 +167,7 @@ ze_weapons_round_flash "2"
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_obj_eclipsis.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_eclipsis.cfg
@@ -167,7 +167,7 @@ ze_weapons_round_flash "2"
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_obj_eclipsis.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_eclipsis.cfg
@@ -161,13 +161,13 @@ ze_weapons_round_decoy "10"
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "3"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "1"
+ze_weapons_round_smoke "-1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_obj_ember.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_ember.cfg
@@ -168,7 +168,7 @@ ze_weapons_round_flash "2"
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_obj_encounter.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_encounter.cfg
@@ -167,7 +167,7 @@ ze_weapons_round_flash "2"
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_obj_escalation_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_escalation_v1.cfg
@@ -143,19 +143,19 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "18"
+ze_weapons_round_hegrenade "20"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "11"
+ze_weapons_round_molotov "14"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "10"
+ze_weapons_round_decoy "12"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_obj_federation.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_federation.cfg
@@ -114,7 +114,7 @@ ze_knockback_scale "1.4"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.4"
+ze_cash_damage_zombie "1.3"
 
 
 ///
@@ -167,7 +167,7 @@ ze_weapons_round_flash "2"
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_obj_goosestep_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_goosestep_v1.cfg
@@ -114,7 +114,7 @@ ze_knockback_scale "1.3"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.1"
+ze_cash_damage_zombie "1.2"
 
 
 ///
@@ -149,13 +149,13 @@ ze_weapons_round_hegrenade "18"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "10"
+ze_weapons_round_molotov "13"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "8"
+ze_weapons_round_decoy "11"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -167,7 +167,7 @@ ze_weapons_round_flash "2"
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_obj_ouroboros_apollyon.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_ouroboros_apollyon.cfg
@@ -114,7 +114,7 @@ ze_knockback_scale "1.35"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.1"
+ze_cash_damage_zombie "1.25"
 
 
 ///
@@ -149,13 +149,13 @@ ze_weapons_round_hegrenade "18"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "12"
+ze_weapons_round_molotov "15"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "10"
+ze_weapons_round_decoy "12"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -167,7 +167,7 @@ ze_weapons_round_flash "2"
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_obj_redheart.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_redheart.cfg
@@ -115,7 +115,7 @@ ze_knockback_scale "1.35"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.0"
+ze_cash_damage_zombie "1.1"
 
 
 ///
@@ -162,7 +162,7 @@ ze_weapons_round_decoy "12"
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "4"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_obj_rove_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_rove_v1.cfg
@@ -170,7 +170,7 @@ ze_weapons_round_flash "3"
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_multimaps
## 为什么要增加/修改这个东西
目前冷门obj由于地图流程设计导致玩家学习成本过高，通关率极低，基本上仅首通后就再无通关可能性（加图1年只过1~2次），为扶持冷门obj人类方，调整大部分冷门obj地图可开放购买黑洞手雷以提高人类方下限，部分地图再次调高人类各项参数值。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
