### PR TITLE
修改地图数据: ze_maontain_escape

### DIFF
--- a/2001/sharp/configs/maps.json
+++ b/2001/sharp/configs/maps.json
@@ -2990,7 +2990,7 @@
   "ze_maontain_escape": {
     "admin": false,
     "certainTimes": [-1],
-    "cooldown": 140,
+    "cooldown": 80,
     "nomination": true,
     "price": 400,
     "requiredOnline": -1,


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_maontain_escape
## 为什么要增加/修改这个东西
地图难度较低，已为入门图，近期通关较轻松，地图CD远超于高难图和皮肤图，修改地图CD至合理值。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
