### PR TITLE
修改地图参数: ze_kitchen

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_kitchen.cfg
+++ b/2001/csgo/cfg/map-configs/ze_kitchen.cfg
@@ -144,13 +144,13 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "10"
+ze_weapons_round_hegrenade "8"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "6"
+ze_weapons_round_molotov "4"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_kitchen.cfg
+++ b/2001/csgo/cfg/map-configs/ze_kitchen.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "0.3"
+sv_falldamage_scale "0.0"
 
 
 ///
@@ -239,7 +239,7 @@ ze_skill_cirrus_range "128"
 // 最小值: false
 // 最大值: true
 // 类  型: bool
-ms_flashlight_enabled "false"
+ms_flashlight_enabled "true"
 
 
 Echo Executed config for ze_kitchen.

--- a/2001/csgo/cfg/map-configs/ze_kitchen.cfg
+++ b/2001/csgo/cfg/map-configs/ze_kitchen.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.25"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.0"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.8"
+ze_cash_damage_zombie "0.9"
 
 
 ///
@@ -144,25 +144,25 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "6"
+ze_weapons_round_hegrenade "10"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "2"
+ze_weapons_round_molotov "6"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "1"
+ze_weapons_round_decoy "3"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "1"
+ze_weapons_round_flash "2"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "2"
+ze_weapons_round_adrenaline "4"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_kitchen
## 为什么要增加/修改这个东西
经实战测试，地图难度很高，且为大开口地图，守点时间长且压力大，有地图伤害较高，地图全图均为大落差降落，存在摔伤无法游玩，且部分区域较黑。原参数道具较少需增加，且适当调高击退与打钱比，因此需关闭摔伤并开启手电筒
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
