### PR TITLE
修改地图参数: ze_amdaporkeep

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_amdaporkeep.cfg
+++ b/2001/csgo/cfg/map-configs/ze_amdaporkeep.cfg
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "0"
+ze_weapons_round_adrenaline "-1"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_amdaporkeep.cfg
+++ b/2001/csgo/cfg/map-configs/ze_amdaporkeep.cfg
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "2"
+ze_weapons_round_adrenaline "0"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_amdaporkeep
## 为什么要增加/修改这个东西
该图有两个奶神器,地图本身其实已经限制了血针购买
若给血针会导致就算只有一个奶的情况下大概率也正常通关
故删除血针
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
