### PR TITLE
修改地图参数: ze_ffxiv_pharos_sirius_night

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
@@ -70,7 +70,7 @@ ze_infect_sort_by_immunity "true"
 // 最小值: 1
 // 最大值: 64
 // 类  型: int32
-ze_infect_mother_ratio "7"
+ze_infect_mother_ratio "6"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: false

--- a/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.2"
+ze_knockback_scale "1.0"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.05"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "-1"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "1"
+ze_weapons_round_adrenaline "-1"
 
 
 ///
@@ -197,7 +197,7 @@ ze_skill_faster_speed "1.4"
 // 最小值: 48.0
 // 最大值: 1000.0
 // 类  型: float
-ze_skill_blader_damage "64.0"
+ze_skill_blader_damage "48.0"
 
 // 说  明: 恶魔技能连锁次数 (次)
 // 最小值: 3

--- a/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.05"
+ze_knockback_scale "1.0"
 
 
 ///
@@ -150,7 +150,7 @@ ze_weapons_round_hegrenade "5"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "2"
+ze_weapons_round_molotov "-1"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
@@ -150,7 +150,7 @@ ze_weapons_round_hegrenade "5"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "-1"
+ze_weapons_round_molotov "1"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "1.05"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.0"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.05"
+ze_cash_damage_zombie "1.0"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
@@ -144,7 +144,7 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "5"
+ze_weapons_round_hegrenade "4"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
@@ -115,7 +115,7 @@ ze_knockback_scale "1.05"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.0"
+ze_cash_damage_zombie "1.1"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffxiv_pharos_sirius_night.cfg
@@ -115,7 +115,7 @@ ze_knockback_scale "1.0"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.0"
+ze_cash_damage_zombie "1.05"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffxiv_pharos_sirius_night
## 为什么要增加/修改这个东西
经观察击退给的太高,调低
降低雷火数量提升撤退的压力
这张图本身不应该存在血针,并且调低刀锋伤害
提高尸变比提升前几个点守点压力
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
