### PR TITLE
修改地图参数: ze_ffvii_cosmo_canyon_v5_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_ffvii_cosmo_canyon_v5_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffvii_cosmo_canyon_v5_p.cfg
@@ -233,7 +233,7 @@ ze_skill_cirrus_range "128"
 // 最小值: 256
 // 最大值: 5000
 // 类  型: int32
-ze_skill_smoker_range "500"
+ze_skill_smoker_range "256"
 
 
 


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffvii_cosmo_canyon_v5_p
## 为什么要增加/修改这个东西
因为神器对抗图所以把钩子僵尸射程给调低
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
