### PR TITLE
修改地图数据: ze_endless_dream

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_endless_dream.cfg
+++ b/2001/csgo/cfg/map-configs/ze_endless_dream.cfg
@@ -19,7 +19,7 @@
 // 最小值: 1
 // 最大值: 70
 // 类  型: float
-mp_timelimit "45.0"
+mp_timelimit "65.0"
 
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
@@ -233,7 +233,7 @@ ze_skill_cirrus_range "128"
 // 最小值: 256
 // 最大值: 5000
 // 类  型: int32
-ze_skill_smoker_range "500"
+ze_skill_smoker_range "300"
 
 
 

--- a/2001/csgo/cfg/map-configs/ze_endless_dream.cfg
+++ b/2001/csgo/cfg/map-configs/ze_endless_dream.cfg
@@ -233,7 +233,7 @@ ze_skill_cirrus_range "128"
 // 最小值: 256
 // 最大值: 5000
 // 类  型: int32
-ze_skill_smoker_range "300"
+ze_skill_smoker_range "500"
 
 
 


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_endless_dream
## 为什么要增加/修改这个东西
本图共八关，流程分别为12，9，9，9，14，3，3，3分钟，共62分钟，加上ext已被禁用，故调高地图时间
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
