### PR TITLE
修改地图参数: ze_umbra

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_umbra.cfg
+++ b/2001/csgo/cfg/map-configs/ze_umbra.cfg
@@ -115,7 +115,7 @@ ze_knockback_scale "1.3"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.0"
+ze_cash_damage_zombie "0.9"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_umbra.cfg
+++ b/2001/csgo/cfg/map-configs/ze_umbra.cfg
@@ -115,7 +115,7 @@ ze_knockback_scale "1.3"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.1"
+ze_cash_damage_zombie "1.0"
 
 
 ///
@@ -132,7 +132,7 @@ ze_weapons_spawn_hegrenade "1"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_molotov "1"
+ze_weapons_spawn_molotov "0"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
@@ -144,7 +144,7 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "12"
+ze_weapons_round_hegrenade "6"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -156,7 +156,7 @@ ze_weapons_round_molotov "6"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "3"
+ze_weapons_round_decoy "2"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "4"
+ze_weapons_round_adrenaline "3"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_umbra
## 为什么要增加/修改这个东西
地图测试参数结束且整体打法趋于成熟,下调人类方强度:
1. 下调人类``打钱比例 1.1->0.9``
2. 删除``初始火瓶``
3. 由于地图存在给予人类方手雷的神器,削弱购买``手雷道具上限12->6``.
4. 下调人类方``血针数量4->3``

## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
