### PR TITLE
修改地图参数: ze_obf_rampage_v2

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obf_rampage_v2.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_rampage_v2.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.15"
+ze_knockback_scale "1.35"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.15"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.35"
+ze_cash_damage_zombie "1.25"
 
 
 ///
@@ -150,19 +150,19 @@ ze_weapons_round_hegrenade "20"
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "13"
+ze_weapons_round_molotov "15"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "10"
+ze_weapons_round_decoy "13"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "3"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
@@ -233,7 +233,7 @@ ze_skill_cirrus_range "108"
 // 最小值: 256
 // 最大值: 5000
 // 类  型: int32
-ze_skill_smoker_range "500"
+ze_skill_smoker_range "256"
 
 
 


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obf_rampage_v2
## 为什么要增加/修改这个东西
目前参数人类相对高压，认路成本不低于其他obj类型地图，故将人类参数回退至上一版本。
同时该图僵尸进攻角度多且距离与人类贴脸，钩子在目前版本较为强势，将钩子距离削减至256.
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
