### PR TITLE
修改地图参数: ze_lostclue_cs2_l

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_lostclue_cs2_l.cfg
+++ b/2001/csgo/cfg/map-configs/ze_lostclue_cs2_l.cfg
@@ -168,7 +168,7 @@ ze_weapons_round_flash "1"
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_lostclue_cs2_l
## 为什么要增加/修改这个东西
人类防守过于困难，恢复黑洞类购买
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
