### PR TITLE
修改地图翻译: ze_ffxii_westersand_v8

### DIFF
--- a/2001/sharp/configs/translations/ze_ffxii_westersand_v8.jsonc
+++ b/2001/sharp/configs/translations/ze_ffxii_westersand_v8.jsonc
@@ -24,7 +24,7 @@
     "translation": "守卫已被击败,离开这里!"
   },
   "** The final gate will open in 40 seconds **": {
-    "translation": "最终之门40秒后打开"
+    "translation": "最终之门40秒后打开,最后一道门在倒数第四个台阶等人"
   },
   "** The final gate will open in 5 seconds **": {
     "translation": "** The final gate will open in 5 seconds **",

--- a/2001/sharp/configs/translations/ze_ffxii_westersand_v8.jsonc
+++ b/2001/sharp/configs/translations/ze_ffxii_westersand_v8.jsonc
@@ -24,7 +24,7 @@
     "translation": "守卫已被击败,离开这里!"
   },
   "** The final gate will open in 40 seconds **": {
-    "translation": "最终之门40秒后打开,最后一道门在倒数第四个台阶等人"
+    "translation": "最终之门40秒后打开,在倒数第四个台阶等人"
   },
   "** The final gate will open in 5 seconds **": {
     "translation": "** The final gate will open in 5 seconds **",


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffxii_westersand_v8
## 为什么要增加/修改这个东西
补充最后倒计时提示，说明最后一道门的等待位置，避免卖人。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
