### PR TITLE
修改地图参数: ze_backrooms_deathbed_v1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_backrooms_deathbed_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_backrooms_deathbed_v1.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.3"
+ze_knockback_scale "1.15"
 
 ///
 /// Economy
@@ -143,19 +143,19 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "4"
+ze_weapons_round_hegrenade "6"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "2"
+ze_weapons_round_molotov "4"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "1"
+ze_weapons_round_decoy "3"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_backrooms_deathbed_v1
## 为什么要增加/修改这个东西
12分钟左右的非神器对抗地图，目前非svip玩家多的情况下通关较为困难，故将基础道具量调整至正常水平。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
