### PR TITLE
修改地图参数: ze_biohazard2_sewer_004

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_biohazard2_sewer_004.cfg
+++ b/2001/csgo/cfg/map-configs/ze_biohazard2_sewer_004.cfg
@@ -114,7 +114,7 @@ ze_knockback_scale "0.8"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "0.8"
+ze_cash_damage_zombie "1.2"
 
 
 ///
@@ -125,7 +125,7 @@ ze_cash_damage_zombie "0.8"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-ze_weapons_spawn_hegrenade "1"
+ze_weapons_spawn_hegrenade "2"
 
 // 说  明: 每局开始时补给的火瓶数量 (个)
 // 最小值: 0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_biohazard2_sewer_004
## 为什么要增加/修改这个东西
地图部分守点需要大量道具辅助，但该图刷分点极少，金钱压力较大，导致通关率较低.故提升打钱比和初始道具以符合地图难度
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
