### PR TITLE
修改地图参数: ze_obff_npst_v24

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obff_npst_v24.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obff_npst_v24.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.15"
+ze_knockback_scale "1.35"
 
 
 ///
@@ -144,19 +144,19 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "18"
+ze_weapons_round_hegrenade "22"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "10"
+ze_weapons_round_molotov "18"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "10"
+ze_weapons_round_decoy "13"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obff_npst_v24
## 为什么要增加/修改这个东西
该地图现打法成熟的情况下，僵尸操作上限高，现参数人类压力较大。且地图含有真结局情况下道具消耗严重，故提高人类各项数值：
击退1.15->1.35
高爆手雷18->22
燃烧弹10->18
冰冻手雷10->13
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
