### PR TITLE
修改地图参数: ze_obj_redemption_v2

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obj_redemption_v2.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_redemption_v2.cfg
@@ -144,19 +144,19 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "22"
+ze_weapons_round_hegrenade "25"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "15"
+ze_weapons_round_molotov "20"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "14"
+ze_weapons_round_decoy "15"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -168,7 +168,7 @@ ze_weapons_round_flash "3"
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1
@@ -233,7 +233,7 @@ ze_skill_cirrus_range "108"
 // 最小值: 256
 // 最大值: 5000
 // 类  型: int32
-ze_skill_smoker_range "500"
+ze_skill_smoker_range "256"
 
 
 


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_redemption_v2
## 为什么要增加/修改这个东西
地图认路成本过大，守点难度相比其他热门obj地图更高，且boss尸笼机制改动，僵尸操作点更多，故总体增加人类道具量和开放黑洞雷购买。因地图地形设计，钩子僵尸击杀率过高，故调整钩子距离。具体参数如下：
高爆手雷22->25
火瓶15->20
冰冻雷14->15
黑洞手雷0->1
钩子距离长度500->256
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
