### PR TITLE
修改地图参数: ze_obj_rove_v1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obj_rove_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_rove_v1.cfg
@@ -146,31 +146,31 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "22"
+ze_weapons_round_hegrenade "25"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "15"
+ze_weapons_round_molotov "20"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "13"
+ze_weapons_round_decoy "15"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "3"
+ze_weapons_round_flash "4"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "2"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1
@@ -236,7 +236,7 @@ ze_skill_cirrus_range "108"
 // 最小值: 256
 // 最大值: 5000
 // 类  型: int32
-ze_skill_smoker_range "500"
+ze_skill_smoker_range "256"
 
 
 


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_rove_v1
## 为什么要增加/修改这个东西
因该图地形结构特殊，僵尸操作上下限极高，人类认路成本和防守成本巨大，该地图自加图到此刻通关率极低，故再次上调人类各项数值。因贴脸战太多且追尾路频繁，钩子僵尸在此图击杀率极高，故与其他obj类地图一致调整钩子僵尸距离。具体参数：
高爆手雷22->25
火瓶15->20
冰冻雷13->15
屏障雷3->4
黑洞手雷0->2
钩子僵尸距离500->256
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
