### PR TITLE
修改地图参数: ze_obf_filth_v1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obf_filth_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_filth_v1.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.15"
+ze_knockback_scale "1.3"
 
 ///
 /// Economy
@@ -143,19 +143,19 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "14"
+ze_weapons_round_hegrenade "16"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "9"
+ze_weapons_round_molotov "11"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "8"
+ze_weapons_round_decoy "10"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -232,7 +232,7 @@ ze_skill_cirrus_range "108"
 // 最小值: 256
 // 最大值: 5000
 // 类  型: int32
-ze_skill_smoker_range "500"
+ze_skill_smoker_range "256"
 
 
 


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obf_filth_v1
## 为什么要增加/修改这个东西
目前该参数在简单路情况下，僵尸闪灵破点能力得到提升，人类参数已无法有效支撑通关，故总体调整人类各项参数。因钩子僵尸可以通过多个跨地形操作和尸笼最深处低成本操作人类方，故与其他obj类地图一致调整钩子僵尸长度。调整方案：
击退1.15->1.3
高爆手雷14->16
火瓶9->11
冰冻8->10
钩子距离500->256
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
