### PR TITLE
修改地图翻译: ze_lab_cs2_l

### DIFF
--- a/2001/sharp/configs/translations/ze_lab_cs2_l.jsonc
+++ b/2001/sharp/configs/translations/ze_lab_cs2_l.jsonc
@@ -65,13 +65,13 @@
     "translation": ">>>请稍等<<<"
   },
   ">>>10%<<<": {
-    "translation": ">>>10%<<<"
+    "translation": "百分之十"
   },
   ">>>50%<<<": {
-    "translation": ">>>50%<<<"
+    "translation": "百分之五十"
   },
   ">>>90%<<<": {
-    "translation": ">>>90%<<<"
+    "translation": "百分之九十!坚持住!"
   },
   ">>>Teleport is Online<<<": {
     "translation": ">>>传送器已激活<<<"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_lab_cs2_l
## 为什么要增加/修改这个东西
当前地图翻译内的百分比会激活倒计时播报，调整中文以避免倒计时错误播报。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
