### PR TITLE
修改地图参数: ze_obj_abyss

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obj_abyss.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_abyss.cfg
@@ -143,19 +143,19 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "21"
+ze_weapons_round_hegrenade "25"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "15"
+ze_weapons_round_molotov "20"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "12"
+ze_weapons_round_decoy "15"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -167,7 +167,7 @@ ze_weapons_round_flash "3"
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1
@@ -232,7 +232,7 @@ ze_skill_cirrus_range "108"
 // 最小值: 256
 // 最大值: 5000
 // 类  型: int32
-ze_skill_smoker_range "500"
+ze_skill_smoker_range "256"
 
 
 


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_abyss
## 为什么要增加/修改这个东西
此图渡过开荒期后，经观察在正常对局中萌新认路成本高，老司机断后压力大，贴脸多角度防守点位较多，僵尸追尾压力巨大。故尝试调整人类与僵尸参数平衡：
高爆手雷21->25
火瓶15->20
冰冻雷12->15
黑洞雷0->1
钩子僵尸长度500->256
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
