### PR TITLE
修改地图参数: ze_k19_escape_p

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_k19_escape_p.cfg
+++ b/2001/csgo/cfg/map-configs/ze_k19_escape_p.cfg
@@ -82,7 +82,7 @@ ze_infect_teleport_to_spawn "true"
 // 最小值: 10
 // 最大值: 90
 // 类  型: int32
-ze_infect_mother_spawn_time "15"
+ze_infect_mother_spawn_time "20"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_k19_escape_p
## 为什么要增加/修改这个东西
入门图，开局非洲位人类需15s抵达开黑点，萌新易被欧洲位僵尸抓，故增加开局母体尸变时间
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
