### PR TITLE
修改地图参数: ze_obj_ember

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obj_ember.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_ember.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.35"
+ze_knockback_scale "1.55"
 
 
 ///
@@ -115,7 +115,7 @@ ze_knockback_scale "1.35"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.1"
+ze_cash_damage_zombie "1.5"
 
 
 ///
@@ -144,31 +144,31 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "20"
+ze_weapons_round_hegrenade "25"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "12"
+ze_weapons_round_molotov "20"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "10"
+ze_weapons_round_decoy "15"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "3"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1
@@ -233,7 +233,7 @@ ze_skill_cirrus_range "108"
 // 最小值: 256
 // 最大值: 5000
 // 类  型: int32
-ze_skill_smoker_range "500"
+ze_skill_smoker_range "256"
 
 
 


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_ember
## 为什么要增加/修改这个东西
国产obj，贴脸多且认路成本巨大，为保障人类通关率，大幅度调整人类各项参数。因地图钩子僵尸十分容易操作人类方，为增加其操作成本，降低钩子距离。具体调整如下：
击退1.35->1.55
打钱比1.1->1.5
高爆雷20->25
火瓶12->20
冰冻雷10->15
屏障雷2->3
黑洞雷0->1
钩子僵尸距离500->256
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
