### PR TITLE
修改地图参数: ze_obj_ouroboros_aurora_v2

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obj_ouroboros_aurora_v2.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_ouroboros_aurora_v2.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.45"
+ze_knockback_scale "1.7"
 
 ///
 /// Economy
@@ -114,7 +114,7 @@ ze_knockback_scale "1.45"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.2"
+ze_cash_damage_zombie "1.4"
 
 
 ///
@@ -161,19 +161,19 @@ ze_weapons_round_decoy "15"
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "3"
+ze_weapons_round_flash "5"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "1"
+ze_weapons_round_smoke "3"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "8"
+ze_weapons_round_adrenaline "12"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_ouroboros_aurora_v2
## 为什么要增加/修改这个东西
开荒期观察后，地图难度上升至入土，与孤注一掷对标，调整人类各项参数。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
