### PR TITLE
修改地图通关奖励: ze_biohazard_manor_004_p

### DIFF
--- a/2001/sharp/configs/rewards/ze_biohazard_manor_004_p.jsonc
+++ b/2001/sharp/configs/rewards/ze_biohazard_manor_004_p.jsonc
@@ -13,10 +13,10 @@
 
 {
   "1": {
-    "rankPasses": 6,
+    "rankPasses": 9,
     "rankDamage": 22000,
     "rankIntern": 0.3,
-    "econPasses": 4,
+    "econPasses": 6,
     "econDamage": 24000,
     "econIntern": 0.25
   }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_biohazard_manor_004_p
## 为什么要增加/修改这个东西
该地图一局正常触发为12分钟左右，且该地图不是刷分图，当前奖励偏低，故略微上调
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
