### PR TITLE
修改地图通关奖励: ze_s_a_m

### DIFF
--- a/2001/sharp/configs/rewards/ze_s_a_m.jsonc
+++ b/2001/sharp/configs/rewards/ze_s_a_m.jsonc
@@ -42,15 +42,15 @@
     "rankIntern": 0.6,
     "econPasses": 10,
     "econDamage": 20000,
-    "econIntern": 0.55
+    "econIntern": 0.5
   },
   "5": {
     "rankPasses": 12,
     "rankDamage": 18000,
-    "rankIntern": 0.65,
+    "rankIntern": 0.6,
     "econPasses": 10,
     "econDamage": 20000,
-    "econIntern": 0.55
+    "econIntern": 0.5
   }
 }
 


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_s_a_m
## 为什么要增加/修改这个东西
该地图第四关以及第五关保底奖励在最后几分钟时会产生过高的保底奖励导致无法获得保底奖励,故将保底下调0.05
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
