### PR TITLE
修改地图参数: ze_purification_a1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_purification_a1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_purification_a1.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "1.0"
+sv_falldamage_scale "0.0"
 
 
 ///
@@ -174,7 +174,7 @@ ze_weapons_round_smoke "1"
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_adrenaline "3"
+ze_weapons_round_adrenaline "1"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_purification_a1
## 为什么要增加/修改这个东西
新增第三关，因存在无法避免的高摔伤，且人类无奶神器和存在天谴，血线压力上升，故关闭摔伤。
第三关存在弹幕关，血针太多过于提升容错，故降低血针可购买数量。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
