### PR TITLE
修改地图参数: ze_minecraft_manor_panic

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_minecraft_manor_panic.cfg
+++ b/2001/csgo/cfg/map-configs/ze_minecraft_manor_panic.cfg
@@ -82,7 +82,7 @@ ze_infect_teleport_to_spawn "true"
 // 最小值: 10
 // 最大值: 90
 // 类  型: int32
-ze_infect_mother_spawn_time "15"
+ze_infect_mother_spawn_time "30"
 
 
 ///
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "0.6"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_minecraft_manor_panic.cfg
+++ b/2001/csgo/cfg/map-configs/ze_minecraft_manor_panic.cfg
@@ -82,7 +82,7 @@ ze_infect_teleport_to_spawn "true"
 // 最小值: 10
 // 最大值: 90
 // 类  型: int32
-ze_infect_mother_spawn_time "30"
+ze_infect_mother_spawn_time "15"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_minecraft_manor_panic
## 为什么要增加/修改这个东西
经测试发现在当前神器以及现行参数下僵尸基本没有操作空间，基本都为高低差守点僵尸过于坐牢，故降低击退平衡双方游戏体验
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
