### PR TITLE
修改地图参数: ze_minecraft_manor_panic

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_minecraft_manor_panic.cfg
+++ b/2001/csgo/cfg/map-configs/ze_minecraft_manor_panic.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.0"
+ze_knockback_scale "0.8"
 
 
 ///
@@ -191,19 +191,19 @@ ze_skill_hunter_power "180.0"
 // 最小值: 1.05
 // 最大值: 2.00
 // 类  型: float
-ze_skill_faster_speed "1.4"
+ze_skill_faster_speed "1.8"
 
 // 说  明: 刀锋技能伤害 (unit)
 // 最小值: 48.0
 // 最大值: 1000.0
 // 类  型: float
-ze_skill_blader_damage "64.0"
+ze_skill_blader_damage "100.0"
 
 // 说  明: 恶魔技能连锁次数 (次)
 // 最小值: 3
 // 最大值: 10
 // 类  型: int32
-ze_skill_deimos_amount "5"
+ze_skill_deimos_amount "10"
 
 // 说  明: 赤焰技能伤害 (次)
 // 最小值: 1

--- a/2001/csgo/cfg/map-configs/ze_minecraft_manor_panic.cfg
+++ b/2001/csgo/cfg/map-configs/ze_minecraft_manor_panic.cfg
@@ -197,7 +197,7 @@ ze_skill_faster_speed "1.8"
 // 最小值: 48.0
 // 最大值: 1000.0
 // 类  型: float
-ze_skill_blader_damage "100.0"
+ze_skill_blader_damage "94.0"
 
 // 说  明: 恶魔技能连锁次数 (次)
 // 最小值: 3

--- a/2001/csgo/cfg/map-configs/ze_minecraft_manor_panic.cfg
+++ b/2001/csgo/cfg/map-configs/ze_minecraft_manor_panic.cfg
@@ -197,7 +197,7 @@ ze_skill_faster_speed "1.8"
 // 最小值: 48.0
 // 最大值: 1000.0
 // 类  型: float
-ze_skill_blader_damage "94.0"
+ze_skill_blader_damage "92.0"
 
 // 说  明: 恶魔技能连锁次数 (次)
 // 最小值: 3


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_minecraft_manor_panic
## 为什么要增加/修改这个东西
经测试由于此地图的特殊性，僵尸基本没有操作空间，游戏体验较差，故略微降低击退，增加部分僵尸技能参数，来平衡双方游戏体验
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
