### PR TITLE
修改地图参数: ze_ffxiv_wanderers_palace_v6_2

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_ffxiv_wanderers_palace_v6_2.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffxiv_wanderers_palace_v6_2.cfg
@@ -53,7 +53,7 @@ vip_map_extend_times "2"
 // 最小值: 0.0
 // 最大值: 3.0
 // 类  型: float
-sv_falldamage_scale "1.0"
+sv_falldamage_scale "0.0"
 
 
 ///

--- a/2001/csgo/cfg/map-configs/ze_ffxiv_wanderers_palace_v6_2.cfg
+++ b/2001/csgo/cfg/map-configs/ze_ffxiv_wanderers_palace_v6_2.cfg
@@ -115,7 +115,7 @@ ze_knockback_scale "1.3"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.3"
+ze_cash_damage_zombie "1.5"
 
 
 ///
@@ -144,13 +144,13 @@ ze_weapons_spawn_decoy "0"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "6"
+ze_weapons_round_hegrenade "7"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "2"
+ze_weapons_round_molotov "3"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
@@ -191,7 +191,7 @@ ze_skill_hunter_power "180.0"
 // 最小值: 1.05
 // 最大值: 2.00
 // 类  型: float
-ze_skill_faster_speed "1.4"
+ze_skill_faster_speed "1.1"
 
 // 说  明: 刀锋技能伤害 (unit)
 // 最小值: 48.0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffxiv_wanderers_palace_v6_2

## 为什么要增加/修改这个东西
有高摔伤点,测试的时候已经发现,不关闭摔伤无法正常游玩.所以关闭摔伤
打钱比雷火不够用,boss战经常没钱,同步增加打钱比和雷火`
此图最后一关僵尸地速常驻345.所以修改加速僵尸加速为最低值1.1 开加速技能后加速僵尸移速379.5

## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.