### PR TITLE
修改地图通关奖励: ze_ffxiv_pharos_sirius_night

### DIFF
--- a/2001/sharp/configs/rewards/ze_ffxiv_pharos_sirius_night.jsonc
+++ b/2001/sharp/configs/rewards/ze_ffxiv_pharos_sirius_night.jsonc
@@ -24,7 +24,7 @@
     "rankPasses": 15,
     "rankDamage": 22000,
     "rankIntern": 0.6,
-    "econPasses": 9,
+    "econPasses": 10,
     "econDamage": 24000,
     "econIntern": 0.5
   },

--- a/2001/sharp/configs/rewards/ze_ffxiv_pharos_sirius_night.jsonc
+++ b/2001/sharp/configs/rewards/ze_ffxiv_pharos_sirius_night.jsonc
@@ -13,26 +13,26 @@
 
 {
   "1": {
-    "rankPasses": 7,
+    "rankPasses": 10,
     "rankDamage": 20000,
     "rankIntern": 0.6,
-    "econPasses": 4,
+    "econPasses": 6,
     "econDamage": 22000,
     "econIntern": 0.4
   },
   "2": {
-    "rankPasses": 13,
+    "rankPasses": 15,
     "rankDamage": 22000,
     "rankIntern": 0.6,
-    "econPasses": 8,
+    "econPasses": 9,
     "econDamage": 24000,
     "econIntern": 0.5
   },
   "3": {
-    "rankPasses": 17,
+    "rankPasses": 19,
     "rankDamage": 22000,
     "rankIntern": 0.7,
-    "econPasses": 11,
+    "econPasses": 13,
     "econDamage": 24000,
     "econIntern": 0.6
   }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffxiv_pharos_sirius_night

## 为什么要增加/修改这个东西
之前给的奖励给的太低.
第一关8分钟,第二关11分钟双boss战,第三关12分钟结尾跳刀,据此提高奖励

## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.