### PR TITLE
修改地图通关奖励: ze_ffxiv_wanderers_palace_v5_2

### DIFF
--- a/2001/sharp/configs/rewards/ze_ffxiv_wanderers_palace_v5_2.jsonc
+++ b/2001/sharp/configs/rewards/ze_ffxiv_wanderers_palace_v5_2.jsonc
@@ -13,35 +13,35 @@
 
 {
   "1": {
-    "rankPasses": 8,
+    "rankPasses": 10,
     "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 5,
-    "econDamage": 20000,
-    "econIntern": 0.2
-  },
-  "2": {
-    "rankPasses": 8,
-    "rankDamage": 18000,
-    "rankIntern": 0.4,
+    "rankIntern": 0.5,
     "econPasses": 6,
     "econDamage": 20000,
-    "econIntern": 0.2
+    "econIntern": 0.4
+  },
+  "2": {
+    "rankPasses": 10,
+    "rankDamage": 18000,
+    "rankIntern": 0.55,
+    "econPasses": 7,
+    "econDamage": 20000,
+    "econIntern": 0.45
   },
   "3": {
-    "rankPasses": 12,
+    "rankPasses": 13,
     "rankDamage": 18000,
-    "rankIntern": 0.4,
-    "econPasses": 8,
+    "rankIntern": 0.6,
+    "econPasses": 9,
     "econDamage": 20000,
-    "econIntern": 0.2
+    "econIntern": 0.5
   },
   "4": {
-    "rankPasses": 15,
+    "rankPasses": 17,
     "rankDamage": 18000,
-    "rankIntern": 0.42,
-    "econPasses": 10,
+    "rankIntern": 0.7,
+    "econPasses": 11,
     "econDamage": 20000,
-    "econIntern": 0.35
+    "econIntern": 0.6
   }
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffxiv_wanderers_palace_v5_2

## 为什么要增加/修改这个东西
该地图全程断后,没有刷分点.每关全程断后下来也就20k分左右
整体玩起来断后体验较累,每关大约 7/9/10/11分钟
综合考虑现在整体的奖励偏低,提高地图奖励
地图本身难度拥有较难的boss战和较强僵尸神器,且僵尸每关地速加成越来越快.萌新极易去世增加低保奖励

## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.