### PR TITLE
修改地图通关奖励: ze_stilshrine_of_miriam

### DIFF
--- a/2001/sharp/configs/rewards/ze_stilshrine_of_miriam.jsonc
+++ b/2001/sharp/configs/rewards/ze_stilshrine_of_miriam.jsonc
@@ -21,10 +21,10 @@
     "econIntern": 0.2
   },
   "2": {
-    "rankPasses": 14,
+    "rankPasses": 12,
     "rankDamage": 15000,
     "rankIntern": 0.4,
-    "econPasses": 10,
+    "econPasses": 8,
     "econDamage": 18000,
     "econIntern": 0.2
   },

--- a/2001/sharp/configs/rewards/ze_stilshrine_of_miriam.jsonc
+++ b/2001/sharp/configs/rewards/ze_stilshrine_of_miriam.jsonc
@@ -21,10 +21,10 @@
     "econIntern": 0.2
   },
   "2": {
-    "rankPasses": 8,
+    "rankPasses": 14,
     "rankDamage": 15000,
     "rankIntern": 0.4,
-    "econPasses": 6,
+    "econPasses": 10,
     "econDamage": 18000,
     "econIntern": 0.2
   },
@@ -37,10 +37,10 @@
     "econIntern": 0.22
   },
   "4": {
-    "rankPasses": 13,
+    "rankPasses": 16,
     "rankDamage": 18000,
     "rankIntern": 0.48,
-    "econPasses": 8,
+    "econPasses": 11,
     "econDamage": 20000,
     "econIntern": 0.24
   }

--- a/2001/sharp/configs/rewards/ze_stilshrine_of_miriam.jsonc
+++ b/2001/sharp/configs/rewards/ze_stilshrine_of_miriam.jsonc
@@ -13,34 +13,34 @@
 
 {
   "1": {
-    "rankPasses": 7,
-    "rankDamage": 15000,
-    "rankIntern": 0.4,
-    "econPasses": 4,
-    "econDamage": 18000,
-    "econIntern": 0.2
-  },
-  "2": {
-    "rankPasses": 7,
+    "rankPasses": 8,
     "rankDamage": 15000,
     "rankIntern": 0.4,
     "econPasses": 5,
     "econDamage": 18000,
     "econIntern": 0.2
   },
+  "2": {
+    "rankPasses": 8,
+    "rankDamage": 15000,
+    "rankIntern": 0.4,
+    "econPasses": 6,
+    "econDamage": 18000,
+    "econIntern": 0.2
+  },
   "3": {
-    "rankPasses": 9,
+    "rankPasses": 10,
     "rankDamage": 18000,
     "rankIntern": 0.45,
-    "econPasses": 6,
+    "econPasses": 7,
     "econDamage": 20000,
     "econIntern": 0.22
   },
   "4": {
-    "rankPasses": 12,
+    "rankPasses": 13,
     "rankDamage": 18000,
     "rankIntern": 0.48,
-    "econPasses": 7,
+    "econPasses": 8,
     "econDamage": 20000,
     "econIntern": 0.24
   }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_stilshrine_of_miriam

## 为什么要增加/修改这个东西
当前各关通关奖励整体偏低.第二关流程约10分钟,提高第二关和第四关通关奖励,并小幅提高第一关和第三关.


## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.