### PR TITLE
修改地图数据: ze_steyliff_grove

### DIFF
--- a/2001/sharp/configs/maps.json
+++ b/2001/sharp/configs/maps.json
@@ -5206,8 +5206,8 @@
     "certainTimes": [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
     "cooldown": 120,
     "nomination": true,
-    "price": 700,
-    "requiredOnline": 900,
+    "price": 500,
+    "requiredOnline": 60,
     "requiredPlayers": 45
   },
   "ze_steyliff_grove_r": {

--- a/2001/sharp/configs/maps.json
+++ b/2001/sharp/configs/maps.json
@@ -5207,7 +5207,7 @@
     "cooldown": 120,
     "nomination": true,
     "price": 500,
-    "requiredOnline": 60,
+    "requiredOnline": 600,
     "requiredPlayers": 45
   },
   "ze_steyliff_grove_r": {


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_steyliff_grove
## 为什么要增加/修改这个东西
该图已有全新版本且该图预订的热度也早已下降，作为一张困难图需要预订的时间以及龙晶偏高故调整至正常困难图水平
"price": 700调整至500
"requiredOnline": 900调整至600
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
