### PR TITLE
修改地图参数: ze_mkzk_scarab_v4_remake

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_mkzk_scarab_v4_remake.cfg
+++ b/2001/csgo/cfg/map-configs/ze_mkzk_scarab_v4_remake.cfg
@@ -19,7 +19,7 @@
 // 最小值: 1
 // 最大值: 70
 // 类  型: float
-mp_timelimit "25.0"
+mp_timelimit "35.0"
 
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
@@ -42,7 +42,7 @@ mcr_map_extend_times "0"
 // 最小值: 0
 // 最大值: 2
 // 类  型: int32
-vip_map_extend_times "1"
+vip_map_extend_times "0"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_mkzk_scarab_v4_remake

## 为什么要增加/修改这个东西
由于每次只能五把通关就换图
导致有些地图的关卡不会玩到
故将地图由通关五次换图调整为以地图时间结束后换图
调整地图时间由 25 分钟改为 35 分钟
并把 VIP 延长次数改为 0 次

## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
