### PR TITLE
修改地图数据: ze_obj_rampage_v1_2

### DIFF
--- a/2001/sharp/configs/maps.json
+++ b/2001/sharp/configs/maps.json
@@ -3874,9 +3874,9 @@
     "certainTimes": [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
     "cooldown": 70,
     "nomination": true,
-    "price": 2000,
-    "requiredOnline": 900,
-    "requiredPlayers": 50
+    "price": 1000,
+    "requiredOnline": -1,
+    "requiredPlayers": 30
   },
   "ze_obj_redemption": {
     "admin": false,


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_rampage_v1_2
## 为什么要增加/修改这个东西
暖服类长征地图，现阶段通关较为简单且为热门，但预订门槛过高，故下降订图积分、预订时间和预订所需人数为正常值。
同时因为CD与其他长征类地图相比较短（早期数值调整），故上调地图CD
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
