### PR TITLE
修改地图参数: ze_obf_filth_v1

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obf_filth_v1.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obf_filth_v1.cfg
@@ -184,7 +184,7 @@ ze_weapons_round_adrenaline "8"
 // 最小值: 160.0
 // 最大值: 2000.0
 // 类  型: float
-ze_skill_hunter_power "205.0"
+ze_skill_hunter_power "190.0"
 
 // 说  明: 加速Boost (%)
 // 最小值: 1.05


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obf_filth_v1
## 为什么要增加/修改这个东西
该地图相比其他obf类地图有更加多的跨地形操作优势，闪灵操作上限极高，故回调闪灵数值。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
