### PR TITLE
修改地图参数: ze_obj_blue_depth

### DIFF
--- a/2001/csgo/cfg/map-configs/ze_obj_blue_depth.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_blue_depth.cfg
@@ -104,7 +104,7 @@ ze_spawn_start_health_override "0"
 // 最小值: 0.1
 // 最大值: 6.0
 // 类  型: float
-ze_knockback_scale "1.25"
+ze_knockback_scale "1.35"
 
 ///
 /// Economy
@@ -114,7 +114,7 @@ ze_knockback_scale "1.25"
 // 最小值: 0.1
 // 最大值: 3.0
 // 类  型: float
-ze_cash_damage_zombie "1.1"
+ze_cash_damage_zombie "1.25"
 
 
 ///
@@ -143,31 +143,31 @@ ze_weapons_spawn_decoy "1"
 // 最小值: -1
 // 最大值: 25
 // 类  型: int32
-ze_weapons_round_hegrenade "20"
+ze_weapons_round_hegrenade "25"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 20
 // 类  型: int32
-ze_weapons_round_molotov "14"
+ze_weapons_round_molotov "20"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
 // 类  型: int32
-ze_weapons_round_decoy "12"
+ze_weapons_round_decoy "15"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 5
 // 类  型: int32
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "3"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 3
 // 类  型: int32
-ze_weapons_round_smoke "-1"
+ze_weapons_round_smoke "1"
 
 // 说  明: 每局最多可购买的肾上腺素 (个)
 // 最小值: -1

--- a/2001/csgo/cfg/map-configs/ze_obj_blue_depth.cfg
+++ b/2001/csgo/cfg/map-configs/ze_obj_blue_depth.cfg
@@ -184,7 +184,7 @@ ze_weapons_round_adrenaline "10"
 // 最小值: 160.0
 // 最大值: 2000.0
 // 类  型: float
-ze_skill_hunter_power "205.0"
+ze_skill_hunter_power "190.0"
 
 // 说  明: 加速Boost (%)
 // 最小值: 1.05
@@ -232,7 +232,7 @@ ze_skill_cirrus_range "108"
 // 最小值: 256
 // 最大值: 5000
 // 类  型: int32
-ze_skill_smoker_range "500"
+ze_skill_smoker_range "256"
 
 
 


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_blue_depth
## 为什么要增加/修改这个东西
该图通关率极低。调整方案和其他冷门obj地图一样加强人类道具购买量，回调闪灵和钩子僵尸技能倍率。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
